### PR TITLE
[MENFORCER-138] Rule to ban all transitive dependencies

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
-      <version>1.2</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -52,7 +52,8 @@ public class BanTransitiveDependencies extends AbstractNonCacheableEnforcerRule 
      * Wildcard '*' can be used to in place of specific section
      * (ie group:*:1.0 will match both 'group:artifact:1.0' and 'group:anotherArtifact:1.0') <br>
      * You can override this patterns by using includes.
-     * Invalid and empty patterns will be ignored.
+     * Version is a string representing standard maven version range.
+     * Empty patterns will be ignored.
      */
 	private List<String> excludes;
 	
@@ -62,7 +63,8 @@ public class BanTransitiveDependencies extends AbstractNonCacheableEnforcerRule 
      * This can be a list of artifacts in the format <code>groupId[:artifactId][:version][:type][:scope]</code>.
      * Wildcard '*' can be used to in place of specific section
      * (ie group:*:1.0 will match both 'group:artifact:1.0' and 'group:anotherArtifact:1.0') <br>
-     * Invalid and empty patterns will be ignored.
+     * Version is a string representing standard maven version range.
+     * Empty patterns will be ignored.
      */
 	private List<String> includes;
 

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -1,5 +1,24 @@
 package org.apache.maven.plugins.enforcer;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.Collections;
 import java.util.List;
 

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -1,0 +1,175 @@
+package org.apache.maven.plugins.enforcer;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyGraphBuilder;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+
+/**
+ * This rule bans all transitive dependencies.
+ * There is a configuration option to exclude certain artifacts
+ * from being checked (similar to BannedDependencies).
+ * 
+ * @author Jakub Senko
+ */
+public class BanTransitiveDependencies extends AbstractNonCacheableEnforcerRule implements EnforcerRule
+{
+	
+	private EnforcerRuleHelper helper;
+	
+    /**
+     * Specify the dependencies that will be ignored.
+     * This can be a list of artifacts in the format <code>groupId[:artifactId][:version][:type][:scope]</code>.
+     * Wildcard '*' can be used to in place of specific section
+     * (ie group:*:1.0 will match both 'group:artifact:1.0' and 'group:anotherArtifact:1.0') <br>
+     * You can override this patterns by using includes.
+     * Invalid and empty patterns will be ignored.
+     */
+	private List<String> excludes;
+	
+    /**
+     * Specify the dependencies that will be checked.
+     * These are exceptions to excludes intended for more convenient and finer settings.
+     * This can be a list of artifacts in the format <code>groupId[:artifactId][:version][:type][:scope]</code>.
+     * Wildcard '*' can be used to in place of specific section
+     * (ie group:*:1.0 will match both 'group:artifact:1.0' and 'group:anotherArtifact:1.0') <br>
+     * Invalid and empty patterns will be ignored.
+     */
+	private List<String> includes;
+
+	/**
+	 * Searches dependency tree recursively for transitive dependencies
+	 * that are not excluded, while generating nice info message
+	 * along the way.
+	 */
+	private static boolean searchTree(DependencyNode node, int level, ArtifactMatcher excludes, StringBuilder message)
+	{
+		
+		List<DependencyNode> children = node.getChildren();
+		
+		/*
+		 * if the node is deeper than direct dependency
+		 * and is empty, it is transitive.
+		 * if its not empty it may contain only excluded dependencies
+		 * and does not have to cause failure
+		 */
+		boolean hasTransitiveDependencies = level > 1 && children.size() == 0;
+		
+		boolean excluded = false;
+		
+		/*
+		 * holds recursive message from children,
+		 * will be appended to current message
+		 * if this node has any transitive descendants
+		 * if message is null, don't generate recursive message.
+		 */
+		StringBuilder messageFromChildren =  message == null ? null : new StringBuilder();
+		
+		if(excludes.match(node.getArtifact())) 
+		{
+			// is excluded, we don't care about descendants
+			excluded = true;
+			hasTransitiveDependencies = false;
+		}
+		else
+		{
+			for(DependencyNode childNode: children)
+			{
+				/*
+				 * if any of the children has transitive d.
+				 * so does the parent
+				 */
+				hasTransitiveDependencies = (searchTree(childNode, level + 1, excludes, messageFromChildren)
+						|| hasTransitiveDependencies);
+			}
+		}
+		
+		
+		if((excluded || hasTransitiveDependencies) && message != null) // then generate message
+		{
+			for(int i = 0; i < level; i++) message.append("   ");
+			
+			message.append(node.getArtifact());
+		
+			if(excluded) 
+			{
+				message.append(" [excluded]\n");
+			}
+		
+			if(hasTransitiveDependencies)
+			{
+				if(level == 1) message.append(" has transitive dependencies:");
+		
+				message.append("\n").append(messageFromChildren);
+			}
+		}
+		
+		return hasTransitiveDependencies;
+	}
+	
+
+	public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException
+	{
+		this.helper = helper;
+		
+		if(excludes == null) excludes = Collections.emptyList();
+		if(includes == null) includes = Collections.emptyList();
+		
+		final ArtifactMatcher exclusions = new ArtifactMatcher(excludes, includes);	
+
+		DependencyNode rootNode = null;
+		
+		try
+		{
+			MavenProject project = (MavenProject) helper.evaluate("${project}");
+
+			rootNode = createDependencyGraphBuilder()
+					.buildDependencyGraph(project, null);
+		}
+		catch (Exception e)
+		{
+			throw new EnforcerRuleException("Error: Could not construct dependency tree.", e);
+		}
+
+		if(message == null)
+		{
+			StringBuilder generatedMessage = new StringBuilder();
+			
+			if(searchTree(rootNode, 0, exclusions, generatedMessage))
+			{				
+				throw new EnforcerRuleException(generatedMessage.toString());
+			}
+		}
+		else
+		{
+			if(searchTree(rootNode, 0, exclusions, null))
+			{				
+				throw new EnforcerRuleException(message);
+			}
+		}
+
+	}
+
+	private DependencyGraphBuilder createDependencyGraphBuilder()
+			throws ComponentLookupException
+	{
+		DefaultDependencyGraphBuilder builder = (DefaultDependencyGraphBuilder) helper
+			.getContainer()
+			.lookup(DependencyGraphBuilder.class.getCanonicalName(), "default");
+
+		builder.enableLogging(new ConsoleLogger(ConsoleLogger.LEVEL_DISABLED,
+			"DefaultDependencyGraphBuilder"));
+
+		return builder;
+	}
+
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -78,10 +78,9 @@ public class BanTransitiveDependencies
         List<DependencyNode> children = node.getChildren();
 
         /*
-         * if the node is deeper than direct dependency and is empty, it is transitive. if its not empty it may contain
-         * only excluded dependencies and does not have to cause failure
+         * if the node is deeper than direct dependency and is empty, it is transitive.
          */
-        boolean hasTransitiveDependencies = level > 1 && children.size() == 0;
+        boolean hasTransitiveDependencies = level > 1;
 
         boolean excluded = false;
 

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
@@ -31,147 +31,153 @@ import org.apache.maven.plugins.enforcer.BanTransitiveDependencies;
 
 /**
  * This class is used for matching Artifacts against a list of patterns.
- *  
- * @author Jakub Senko
  * 
- * @see BanTransitiveDependencies 
+ * @author Jakub Senko
+ * @see BanTransitiveDependencies
  */
 public final class ArtifactMatcher
 {
 
-	public static class Pattern
-	{
-		private String pattern;
-		
-		private String[] parts;
-		
-		public Pattern(String pattern)
-		{
-			if(pattern == null) throw new NullPointerException("pattern");
+    public static class Pattern
+    {
+        private String pattern;
 
-			this.pattern = pattern;
-			
-			parts = pattern.split(":", 6);
-			
-			if(parts.length == 6) throw new IllegalArgumentException("Pattern contains too many delimiters."); 
-			
-			for(String part: parts)
-			{
-				if("".equals(part))
-					throw new IllegalArgumentException("Pattern or its part is empty.");
-			}
-		}
-				
-		public boolean match(Artifact artifact) throws InvalidVersionSpecificationException
-		{
-			if(artifact == null) throw new NullPointerException("artifact");
-			
-			switch(parts.length)
-			{
-				case 5:
-					String scope = artifact.getScope();
-		            if ( scope == null || scope.equals( "" ) )
-		            {
-		            	scope = "compile";
-		            }
-		            
-					if(!"*".equals(parts[4]) && !parts[4].equals(scope))
-						return false;
-					
-				case 4:
-					String type = artifact.getType();
-					if ( type == null || type.equals( "" ) )
-					{
-						type = "jar";
-					}
-		            
-					if(!"*".equals(parts[3]) && !parts[3].equals(type))
-						return false;
-					
-				case 3:
-					if(!"*".equals(parts[2]) && !parts[2].equals(artifact.getVersion()))
-					{
-						if(!AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec(parts[2]),
-							new DefaultArtifactVersion( artifact.getVersion() ) ))
-						{
-							return false;
-						}
-					}
-					
-				case 2:
-					if(!"*".equals(parts[1]) && !parts[1].equals(artifact.getArtifactId()))
-						return false;
-					
-				case 1:
-					if(!"*".equals(parts[0]) && !parts[0].equals(artifact.getGroupId()))
-						return false;
-					else
-						return true;
-				default:
-					throw new AssertionError();
-			}
-		}
-		
-		@Override
-		public String toString()
-		{
-			return pattern;
-		}
-	}
-	
-	
-	private Collection<Pattern> patterns = new LinkedList<Pattern>();
-	
-	
-	private Collection<Pattern> ignorePatterns = new LinkedList<Pattern>();
-	
-	/**
-	 * Construct class by providing patterns as strings.
-	 * Empty strings are ignored.
-	 * 
-	 * @throws NullPointerException if any of the arguments is null
-	 */
-	public ArtifactMatcher(final Collection<String> patterns, final Collection<String> ignorePatterns)
-	{
-		if(patterns == null) throw new NullPointerException("patterns");
-		if(ignorePatterns == null) throw new NullPointerException("ignorePatterns");
-		
-		for(String pattern: patterns)
-		{
-			if(pattern != null && !"".equals(pattern))
-			{	
-				this.patterns.add(new Pattern(pattern));
-			}
-		}
-		
-		for(String ignorePattern: ignorePatterns)
-		{
-			if(ignorePattern != null && !"".equals(ignorePattern))
-			{
-				this.ignorePatterns.add(new Pattern(ignorePattern));
-			}
-		}
-	}
-	
-	/**
-	 * Check if artifact matches patterns.
-	 * @throws InvalidVersionSpecificationException 
-	 */
-	public boolean match(Artifact artifact) throws InvalidVersionSpecificationException
-	{
-		for(Pattern pattern: patterns)
-		{
-			if(pattern.match(artifact))
-			{
-				for(Pattern ignorePattern: ignorePatterns)
-				{
-					if(ignorePattern.match(artifact)) return false;
-				}
-				
-				return true;
-			}
-		}
-		
-		return false;
-	}
+        private String[] parts;
+
+        public Pattern( String pattern )
+        {
+            if ( pattern == null )
+                throw new NullPointerException( "pattern" );
+
+            this.pattern = pattern;
+
+            parts = pattern.split( ":", 6 );
+
+            if ( parts.length == 6 )
+                throw new IllegalArgumentException( "Pattern contains too many delimiters." );
+
+            for ( String part : parts )
+            {
+                if ( "".equals( part ) )
+                    throw new IllegalArgumentException( "Pattern or its part is empty." );
+            }
+        }
+
+        public boolean match( Artifact artifact )
+            throws InvalidVersionSpecificationException
+        {
+            if ( artifact == null )
+                throw new NullPointerException( "artifact" );
+
+            switch ( parts.length )
+            {
+                case 5:
+                    String scope = artifact.getScope();
+                    if ( scope == null || scope.equals( "" ) )
+                    {
+                        scope = "compile";
+                    }
+
+                    if ( !"*".equals( parts[4] ) && !parts[4].equals( scope ) )
+                        return false;
+
+                case 4:
+                    String type = artifact.getType();
+                    if ( type == null || type.equals( "" ) )
+                    {
+                        type = "jar";
+                    }
+
+                    if ( !"*".equals( parts[3] ) && !parts[3].equals( type ) )
+                        return false;
+
+                case 3:
+                    if ( !"*".equals( parts[2] ) && !parts[2].equals( artifact.getVersion() ) )
+                    {
+                        if ( !AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( parts[2] ),
+                                                                       new DefaultArtifactVersion(
+                                                                                                   artifact.getVersion() ) ) )
+                        {
+                            return false;
+                        }
+                    }
+
+                case 2:
+                    if ( !"*".equals( parts[1] ) && !parts[1].equals( artifact.getArtifactId() ) )
+                        return false;
+
+                case 1:
+                    if ( !"*".equals( parts[0] ) && !parts[0].equals( artifact.getGroupId() ) )
+                        return false;
+                    else
+                        return true;
+                default:
+                    throw new AssertionError();
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return pattern;
+        }
+    }
+
+    private Collection<Pattern> patterns = new LinkedList<Pattern>();
+
+    private Collection<Pattern> ignorePatterns = new LinkedList<Pattern>();
+
+    /**
+     * Construct class by providing patterns as strings. Empty strings are ignored.
+     * 
+     * @throws NullPointerException if any of the arguments is null
+     */
+    public ArtifactMatcher( final Collection<String> patterns, final Collection<String> ignorePatterns )
+    {
+        if ( patterns == null )
+            throw new NullPointerException( "patterns" );
+        if ( ignorePatterns == null )
+            throw new NullPointerException( "ignorePatterns" );
+
+        for ( String pattern : patterns )
+        {
+            if ( pattern != null && !"".equals( pattern ) )
+            {
+                this.patterns.add( new Pattern( pattern ) );
+            }
+        }
+
+        for ( String ignorePattern : ignorePatterns )
+        {
+            if ( ignorePattern != null && !"".equals( ignorePattern ) )
+            {
+                this.ignorePatterns.add( new Pattern( ignorePattern ) );
+            }
+        }
+    }
+
+    /**
+     * Check if artifact matches patterns.
+     * 
+     * @throws InvalidVersionSpecificationException
+     */
+    public boolean match( Artifact artifact )
+        throws InvalidVersionSpecificationException
+    {
+        for ( Pattern pattern : patterns )
+        {
+            if ( pattern.match( artifact ) )
+            {
+                for ( Pattern ignorePattern : ignorePatterns )
+                {
+                    if ( ignorePattern.match( artifact ) )
+                        return false;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
@@ -1,5 +1,24 @@
 package org.apache.maven.plugins.enforcer.utils;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.Collection;
 import java.util.LinkedList;
 

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
@@ -1,0 +1,157 @@
+package org.apache.maven.plugins.enforcer.utils;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.plugins.enforcer.AbstractVersionEnforcer;
+import org.apache.maven.plugins.enforcer.BanTransitiveDependencies;
+
+/**
+ * This class is used for matching Artifacts against a list of patterns.
+ *  
+ * @author Jakub Senko
+ * 
+ * @see BanTransitiveDependencies 
+ */
+public final class ArtifactMatcher
+{
+
+	public static class Pattern
+	{
+		private String pattern;
+		
+		private String[] parts;
+		
+		public Pattern(String pattern)
+		{
+			if(pattern == null) throw new NullPointerException("pattern");
+				
+			this.pattern = pattern;
+			
+			this.parts = pattern.split(":", 5);
+		}
+				
+		public boolean match(Artifact artifact)
+		{
+			if(artifact == null) return false;
+			
+			switch(parts.length)
+			{
+				case 5:
+		            String scope = artifact.getScope();
+		            if ( scope == null || scope.equals( "" ) )
+		            {
+		                scope = "compile";
+		            }
+		            
+					if(!"*".equals(parts[4]) && !parts[4].equals(scope))
+						return false;
+					
+				case 4:
+		            String type = artifact.getType();
+		            if ( type == null || type.equals( "" ) )
+		            {
+		                type = "jar";
+		            }
+		            
+					if(!"*".equals(parts[3]) && !parts[3].equals(type))
+						return false;
+					
+				case 3:
+					if(!"*".equals(parts[2]) && !parts[2].equals(artifact.getVersion()))
+					{
+						try
+						{
+							if(!AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec(parts[2]),
+									new DefaultArtifactVersion( artifact.getBaseVersion() ) ))
+							{
+								return false;
+							}
+						}
+						catch(InvalidVersionSpecificationException e)
+						{
+							// TODO
+							return false;
+						}
+					}
+					
+				case 2:
+					if(!"*".equals(parts[1]) && !parts[1].equals(artifact.getArtifactId()))
+						return false;
+					
+				case 1:
+					if(!"*".equals(parts[0]) && !parts[0].equals(artifact.getGroupId()))
+						return false;
+					else
+						return true;
+				default:
+					throw new AssertionError();
+			}
+		}
+		
+		@Override
+		public String toString()
+		{
+			return pattern;
+		}
+	}
+	
+	
+	private Collection<Pattern> patterns = new LinkedList<Pattern>();
+	
+	
+	private Collection<Pattern> ignorePatterns = new LinkedList<Pattern>();
+	
+	/**
+	 * Construct class by providing patterns as strings.
+	 * Empty strings are ignored.
+	 * 
+	 * @throws NullPointerException if any of the arguments is null
+	 */
+	public ArtifactMatcher(final Collection<String> patterns, final Collection<String> ignorePatterns)
+	{
+		if(patterns == null) throw new NullPointerException("patterns");
+		if(ignorePatterns == null) throw new NullPointerException("ignorePatterns");
+		
+		for(String exclude: patterns)
+		{
+			if(exclude != null && !"".equals(exclude))
+			{	
+				this.patterns.add(new Pattern(exclude));
+			}
+		}
+		
+		for(String include: ignorePatterns)
+		{
+			if(include != null && !"".equals(include))
+			{
+				this.ignorePatterns.add(new Pattern(include));
+			}
+		}
+	}
+	
+	/**
+	 * Check if artifact matches patterns.
+	 */
+	public boolean match(Artifact artifact)
+	{
+		for(Pattern pattern: patterns)
+		{
+			if(pattern.match(artifact))
+			{
+				for(Pattern ignorePattern: ignorePatterns)
+				{
+					if(ignorePattern.match(artifact)) return false;
+				}
+				
+				return true;
+			}
+		}
+		
+		return false;
+	}
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactMatcher.java
@@ -69,21 +69,21 @@ public final class ArtifactMatcher
 			switch(parts.length)
 			{
 				case 5:
-		            String scope = artifact.getScope();
+					String scope = artifact.getScope();
 		            if ( scope == null || scope.equals( "" ) )
 		            {
-		                scope = "compile";
+		            	scope = "compile";
 		            }
 		            
 					if(!"*".equals(parts[4]) && !parts[4].equals(scope))
 						return false;
 					
 				case 4:
-		            String type = artifact.getType();
-		            if ( type == null || type.equals( "" ) )
-		            {
-		                type = "jar";
-		            }
+					String type = artifact.getType();
+					if ( type == null || type.equals( "" ) )
+					{
+						type = "jar";
+					}
 		            
 					if(!"*".equals(parts[3]) && !parts[3].equals(type))
 						return false;

--- a/enforcer-rules/src/site/apt/banTransitiveDependencies.apt.vm
+++ b/enforcer-rules/src/site/apt/banTransitiveDependencies.apt.vm
@@ -1,0 +1,89 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.    
+ 
+  ------
+  Ban Transitive Dependencies
+  ------
+  ------
+  August 2012
+  ------
+
+Ban Transitive Dependencies
+
+  This rule bans all transitive dependencies.
+
+
+   The following parameters are supported by this rule:
+   
+   * excludes - specify the dependencies that will be ignored.\
+      This can be a list of artifacts in the format
+      groupId[:artifactId[:version[:type[:scope]]]] .
+      Wildcard '*' can be used to in place of specific section (e.g. group:*:1.0 will match both 'group:artifact:1.0' and 'group:anotherArtifact:1.0')
+      Version is a string representing standard maven version range. Empty patterns will be ignored. 
+
+   * includes - specify the dependencies that will be checked.\
+     These are exceptions to excludes intended for more convenient configuration. This can be a list of artifacts in the format
+     groupId[:artifactId[:version[:type[:scope]]]] as above.
+ 
+   * message - an optional message to the user if the rule fails. Will replace generated report message.
+   
+   []
+
+   
+  Sample Plugin Configuration:
+  
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banTransitiveDependencies>
+                  <excludes>
+                    <!-- the rule will not fail even if it detects ignoredArtifact
+                         of group org.apache.maven, because it is excluded -->
+                    <exclude>org.apache.maven:ignoredArtifact</exclude>
+                    <exclude>*:anotherIgnoredArtifact</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- override "org.apache.maven:ignoredArtifact" to fail
+                         if exactly 1.0 version of ignoreArtifact is detected
+                         to be transitive dependency of the project -->
+                    <include>org.apache.maven:ignoredArtifact:[1.0]</include>
+                  </includes>
+                </banTransitiveDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -32,6 +32,8 @@ Standard Rules
   * {{{./alwaysFail.html}alwaysFail}} - Always fail... used to test plugin configuration.
  
   * {{{./bannedDependencies.html}bannedDependencies}} - enforces that excluded dependencies aren't included.
+  
+  * {{{./banTransitiveDependencies.html}banTransitiveDependencies}} - enforces that project doesn't have transitive dependencies.
 
   * bannedPlugins - enforces that excluded plugins aren't included.
   

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
@@ -1,5 +1,24 @@
 package org.apache.maven.plugins.enforcer.utils;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
@@ -1,0 +1,122 @@
+package org.apache.maven.plugins.enforcer.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+
+import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher.Pattern;
+
+import junit.framework.TestCase;
+
+public class TestArtifactMatcher extends TestCase
+{
+	private ArtifactMatcher matcher;
+	
+	Collection<String> patterns = new ArrayList<String>();
+	
+	Collection<String> ignorePatterns = new ArrayList<String>();
+	
+	public void testPatternInvalidInput() throws InvalidVersionSpecificationException
+	{
+		try
+		{
+			new Pattern(null);
+			fail("NullPointerException expected.");
+		}
+		catch(NullPointerException e){}
+		
+		try
+		{
+			new Pattern("a:b:c:d:e:f");
+			fail("IllegalArgumentException expected.");
+		}
+		catch(IllegalArgumentException e){}
+		
+		try
+		{
+			new Pattern("a::");
+			fail("IllegalArgumentException expected.");
+		}
+		catch(IllegalArgumentException e){}
+		
+		try
+		{
+			Pattern p = new Pattern("*");
+			p.match(null);
+			fail("NullPointerException expected.");
+		}
+		catch(NullPointerException e){}
+	}
+	
+	public void testPattern() throws InvalidVersionSpecificationException
+	{
+		executePatternMatch("groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "compile", "jar", true);
+		
+		executePatternMatch("groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "", "", true);
+		
+		executePatternMatch("groupId:artifactId:1.0", "groupId", "artifactId", "1.0", "", "", true);
+		
+		executePatternMatch("groupId:artifactId:1.0", "groupId", "artifactId", "1.1", "", "", true);
+		
+		executePatternMatch("groupId:artifactId:[1.0]", "groupId", "artifactId", "1.1", "", "", false);
+		
+		executePatternMatch("groupId:*:1.0", "groupId", "artifactId", "1.0", "test", "", true);
+		
+		executePatternMatch("*:*:1.0", "groupId", "artifactId", "1.0", "", "", true);
+		
+		executePatternMatch("*:artifactId:*", "groupId", "artifactId", "1.0", "", "", true);
+		
+		executePatternMatch("*", "groupId", "artifactId", "1.0", "", "", true);
+	}
+	
+	public void testMatch() throws InvalidVersionSpecificationException
+	{
+		patterns.add("groupId:artifactId:1.0");
+		patterns.add("*:anotherArtifact");
+		
+		ignorePatterns.add("badGroup:*:*:test");
+		ignorePatterns.add("*:anotherArtifact:1.1");
+		
+		matcher = new ArtifactMatcher(patterns, ignorePatterns);
+		
+		executeMatch(matcher, "groupId", "artifactId", "1.0", "", "", true);	
+		
+		executeMatch(matcher, "groupId", "anotherArtifact", "1.0", "", "", true);	
+		
+		executeMatch(matcher, "badGroup", "artifactId", "1.0", "", "test", false);
+		
+		executeMatch(matcher, "badGroup", "anotherArtifact", "1.0", "", "", true);	
+		
+		executeMatch(matcher, "groupId", "anotherArtifact", "1.1", "", "", false);	
+	}
+	
+	private void executePatternMatch(final String pattern, final String groupId, final String artifactId,
+			final String versionRange, final String scope, final String type, boolean expectedResult)
+			throws InvalidVersionSpecificationException
+	{
+		assertEquals(expectedResult, new ArtifactMatcher.Pattern(pattern).match(createMockArtifact(groupId, artifactId, versionRange, scope, type)));
+	}
+	
+	
+	private void executeMatch(final ArtifactMatcher matcher, final String groupId, final String artifactId,
+			final String versionRange, final String scope, final String type, final boolean expectedResult) throws InvalidVersionSpecificationException
+	{
+		assertEquals(expectedResult, matcher.match(createMockArtifact(groupId, artifactId, versionRange, scope, type)));
+	}
+	
+	
+	private static Artifact createMockArtifact(final String groupId, final String artifactId,
+			final String versionRange, final String scope, final String type)
+	{
+		ArtifactHandler artifactHandler = new DefaultArtifactHandler();
+		
+		VersionRange version = VersionRange.createFromVersion(versionRange);
+		return new DefaultArtifact(groupId, artifactId, version, scope, type, "", artifactHandler);
+	}
+}

--- a/maven-enforcer-plugin/src/it/ban-transitive-dependencies-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/ban-transitive-dependencies-fail/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/ban-transitive-dependencies-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/ban-transitive-dependencies-fail/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>ban-transitive-fail-test</artifactId>
+  <version>1.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <BanTransitiveDependencies>
+                  <excludes>
+                    <exclude>junit:junit</exclude>
+                    <exclude>classworlds:classworlds</exclude>
+                    <exclude>org.codehaus.plexus:plexus-io</exclude>
+                  </excludes>
+                </BanTransitiveDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>2.1.1</version>
+    </dependency>  
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0</version>
+    </dependency>  
+  </dependencies>
+
+</project>

--- a/maven-enforcer-plugin/src/it/ban-transitive-dependencies/pom.xml
+++ b/maven-enforcer-plugin/src/it/ban-transitive-dependencies/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>ban-transitive-test</artifactId>
+  <version>1.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <BanTransitiveDependencies>
+                  <excludes>
+                    <exclude>org.codehaus.plexus:plexus-container-default</exclude>
+                    <exclude>org.codehaus.plexus:plexus-io</exclude>
+                  </excludes>
+                </BanTransitiveDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>2.1.1</version>
+    </dependency>  
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0</version>
+    </dependency>  
+  </dependencies>
+
+</project>


### PR DESCRIPTION
In some projects it's desirable to have all dependencies specified in pom. It would be nice to have an enforcer rule that would ban all transitive dependencies so that the user could either add the transitive dependency directly to the pom (if it's actually needed), or exclude the dependency.
http://jira.codehaus.org/browse/MENFORCER-138

This rule will ban all transitive dependencies, unless configured otherwise.
The configuration works identically to http://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html .
User can exclude certain dependencies from being checked (anywhere in the dependency tree) add also add exceptions to the excludes for finer configuration (see javadoc for details).

If it fails, the rule will generate message showing dependencies which caused the failure and their descendants in a tree, with info which dependencies were excluded in that branch. Alternatively, custom message can be used.