### PR TITLE
add a IT case for bannedDependencies in a multi module project

### DIFF
--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/mod1/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/mod1/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+  	<groupId>org.apache.maven.its.enforcer</groupId>
+    <artifactId>test-multimodule-project</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>test-multimodule-mod1</artifactId>
+
+  <description>
+  </description>
+
+</project>

--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/mod2/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/mod2/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+  	<groupId>org.apache.maven.its.enforcer</groupId>
+    <artifactId>test-multimodule-project</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>test-multimodule-mod2</artifactId>
+
+  <description>
+  </description>
+  
+  <dependencies>
+  	<dependency>
+ 	  <groupId>${project.groupId}</groupId>
+	  <artifactId>test-multimodule-mod1</artifactId>
+  	</dependency>
+  </dependencies>
+
+</project>

--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-multi-module/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>test-multimodule-project</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <description>
+  </description>
+
+  <modules>
+  	<module>mod1</module>
+  	<module>mod2</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+ 	    <groupId>${project.groupId}</groupId>
+	    <artifactId>test-multimodule-mod1</artifactId>
+	    <version>${project.version}</version>
+  	  </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <BannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.maven.plugins.enforcer.its:menforcer72_logging</exclude>
+                  </excludes>
+                </BannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
If you have a multi module project an have defined a local dependency (like web-module depends on core-module), the "bannedDependencies" rule fails with "org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException: Could not resolve dependencies for project org.apache.maven.its.enforcer:test-multimodule-mod2:jar:1.0: Could not find artifact".

I created a issue on codehaus http://jira.codehaus.org/browse/MENFORCER-168
