### PR TITLE
MENFORCER-183: Update versions of site and project-info-reports plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,12 +253,22 @@
             <tryUpdate>true</tryUpdate>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.3</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
   <reporting>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
to be compatible with Maven 3.1.1. See http://jira.codehaus.org/browse/MENFORCER-183
