### PR TITLE
[MENFORCER-193]: Add new rule: BannedRepositories to ban specified repos...

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedRepositories.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedRepositories.java
@@ -1,0 +1,221 @@
+package org.apache.maven.plugins.enforcer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * This rule checks that this project's maven session whether have banned repositories.
+ * 
+ * @author <a href="mailto:wangyf2010@gmail.com">Simon Wang</a>
+ */
+public class BannedRepositories
+    extends AbstractNonCacheableEnforcerRule
+{
+
+    // ----------------------------------------------------------------------
+    // Mojo parameters
+    // ----------------------------------------------------------------------
+
+    /**
+     * Specify explicitly banned non-plugin repositories. This is a list of repository url patterns. Support wildcard
+     * "*".
+     * 
+     * @see {@link #setBannedRepositories(List)}
+     */
+    private List<String> bannedRepositories = Collections.emptyList();
+
+    /**
+     * Specify explicitly banned plugin repositories. This is a list of repository url patterns. Support wildcard "*".
+     * 
+     * @see {@link #setBannedPluginRepositories(List)}
+     */
+    private List<String> bannedPluginRepositories = Collections.emptyList();
+
+    /**
+     * Specify explicitly allowed non-plugin repositories, then all others repositories would be banned. This is a list
+     * of repository url patterns. Support wildcard "*".
+     * 
+     * @see {@link #setAllowedRepositories(List)}
+     */
+    private List<String> allowedRepositories = Collections.emptyList();
+
+    /**
+     * Specify explicitly allowed plugin repositories, then all others repositories would be banned. This is a list of
+     * repository url patterns. Support wildcard "*".
+     * 
+     * @see {@link #setAllowedPluginRepositories(List)}
+     */
+    private List<String> allowedPluginRepositories = Collections.emptyList();
+
+    // ----------------------------------------------------------------------
+    // Public methods
+    // ----------------------------------------------------------------------
+
+    /*
+     * (non-Javadoc)
+     * @see
+     * org.apache.maven.enforcer.rule.api.EnforcerRule#execute(org.apache.maven.enforcer.rule.api.EnforcerRuleHelper)
+     */
+    @SuppressWarnings( "unchecked" )
+    public void execute( EnforcerRuleHelper helper )
+        throws EnforcerRuleException
+    {
+        MavenProject project;
+        try
+        {
+            project = (MavenProject) helper.evaluate( "${project}" );
+
+            List<ArtifactRepository> resultBannedRepos =
+                checkRepositories( project.getRemoteArtifactRepositories(), this.allowedRepositories,
+                                   this.bannedRepositories );
+
+            List<ArtifactRepository> resultBannedPluginRepos =
+                checkRepositories( project.getPluginArtifactRepositories(), this.allowedPluginRepositories,
+                                   this.bannedPluginRepositories );
+
+            String repoErrMsg = populateErrorMessage( resultBannedRepos, " " );
+            String pluginRepoErrMsg = populateErrorMessage( resultBannedPluginRepos, " plugin " );
+
+            String errMsg = repoErrMsg + pluginRepoErrMsg;
+
+            if ( errMsg != null && !StringUtils.isEmpty( errMsg.toString() ) )
+            {
+                throw new EnforcerRuleException( errMsg.toString() );
+            }
+
+        }
+        catch ( ExpressionEvaluationException e )
+        {
+            throw new EnforcerRuleException( e.getLocalizedMessage() );
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Protected methods
+    // ----------------------------------------------------------------------
+
+    protected void setBannedRepositories( List<String> bannedRepositories )
+    {
+        this.bannedRepositories = bannedRepositories;
+    }
+
+    protected void setBannedPluginRepositories( List<String> bannedPluginRepositories )
+    {
+        this.bannedPluginRepositories = bannedPluginRepositories;
+    }
+
+    protected void setAllowedRepositories( List<String> allowedRepositories )
+    {
+        this.allowedRepositories = allowedRepositories;
+    }
+
+    protected void setAllowedPluginRepositories( List<String> allowedPluginRepositories )
+    {
+        this.allowedPluginRepositories = allowedPluginRepositories;
+    }
+
+    // ----------------------------------------------------------------------
+    // Private methods
+    // ----------------------------------------------------------------------
+    
+    /**
+     * Check whether specified repositories have banned repositories. 
+     * 
+     * @param repositories: candidate repositories.
+     * @param includes : 'include' patterns.
+     * @param excludes : 'exclude' patterns.
+     * @return Banned repositories.
+     */
+    private List<ArtifactRepository> checkRepositories( List<ArtifactRepository> repositories, List<String> includes,
+                                                        List<String> excludes )
+    {
+        List<ArtifactRepository> bannedRepos = new ArrayList<ArtifactRepository>();
+
+        for ( ArtifactRepository repo : repositories )
+        {
+            String url = repo.getUrl().trim();
+            if ( includes.size()>0 && !match( url, includes ) )
+            {
+                bannedRepos.add( repo );
+                continue;
+            }
+
+            if ( excludes.size()>0 && match( url, excludes ) )
+            {
+                bannedRepos.add( repo );
+            }
+
+        }
+
+        return bannedRepos;
+    }
+
+    private boolean match( String url, List<String> patterns )
+    {
+        for ( String pattern : patterns )
+        {
+            if ( this.match( url, pattern ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean match( String text, String pattern )
+    {
+        return text.matches( pattern.replace( "?", ".?" ).replace( "*", ".*?" ) );
+    }
+    
+    private String populateErrorMessage( List<ArtifactRepository> resultBannedRepos, String errorMessagePrefix )
+    {
+        StringBuffer errMsg = new StringBuffer( "" );
+        if ( !resultBannedRepos.isEmpty() )
+        {
+            errMsg.append( "Current maven session contains banned" + errorMessagePrefix
+                + "repository urls, please double check your pom or settings.xml:\n"
+                + getRepositoryUrlString( resultBannedRepos ) + "\n\n" );
+        }
+
+        return errMsg.toString();
+    }
+
+    private String getRepositoryUrlString( List<ArtifactRepository> resultBannedRepos )
+    {
+        StringBuffer urls = new StringBuffer( "" );
+        for ( ArtifactRepository repo : resultBannedRepos )
+        {
+            urls.append( repo.getId() + " - " + repo.getUrl() + "\n" );
+        }
+        return urls.toString();
+    }
+
+}

--- a/enforcer-rules/src/site/apt/bannedRepositories.apt.vm
+++ b/enforcer-rules/src/site/apt/bannedRepositories.apt.vm
@@ -1,0 +1,119 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Banned Specified Repositories
+  ------
+  Simon Wang
+  ------
+  June 2014
+  ------
+
+Banned Specified Repositories
+
+   This rule checks whether this maven session (defined in pom files or even settings.xml) include specified banned repository.
+
+* What's difference from "requireNoRepositories"?
+
+   The purpose for "requireNoRepositories" is: Detect whether pom and pom’s parents contains repositories definition. That guide users to use correct convention (not define repositories in pom files). So it only analyze current pom and its parent pom files.
+
+   But “BannedRepositories” is different purpose, it’s just like “BannedDependencies”. It will detect banned repositories from maven session context instead of only pom.xml and parents. It's trying to avoid misuse incorrect repositories. It will detect banned repositories from current maven session context.
+
+* Support Parameters
+
+   * banRepositories - Specify banned non-plugin repositories. This is a black list of http/https url patterns.
+
+   * banPluginRepositories - Specify banned plugin repositories. This is a black list of http/https url patterns.
+
+   * allowedRepositories - Specify explicitly allowed non-plugin repositories. This is a white list of http/https url patterns.
+
+   * allowedPluginRepositories - Specify explicitly allowed plugin repositories. This is a white list of http/https url patternes.
+
+* Sample Configuration
+
+   For example, one company want to limit repositories usage. But different developers might use different settings.xml.
+   Even their projects' pom defined different repostories too.
+   For this case, could leverage this enforcer rule to banned specified repositories or even use allowedRepositories/allowedPluginRepositories to banned others unexpected repositories.
+   
+   Ex. http://repo1/xyz is the repository that want to be banned.
+       http://repo2/xyz is the repository that want to use now.
+   
+   Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-banned-repositories</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedRepositories>
+                  <bannedRepositories>
+                    <bannedRepository>http://repo1/*<bannedRepository>
+                  </bannedRepositories>
+                  <bannedPluginRepositories>
+                    <bannedPluginRepository>http://repo1/*<bannedPluginRepository>
+                  </bannedPluginRepositories>
+				  
+                  <!-- for some cases, white list is more effective -->
+                  <!--
+				  
+                  <allowedRepositories>
+                    <allowedRepository>http://repo2/*<allowedRepository>
+                  </allowedRepositories>
+                  <allowedPluginRepositories>
+                    <allowedPluginRepository>http://repo2/*<allowedPluginRepository>
+                  </allowedPluginRepositories>
+				  
+                  -->
+                </bannedRepositories>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+
+
+* Worth to Note
+
+   * http/https url patterns support wildcard "*"
+   
+   * This rule will detect banned repositories on maven session itself istead of pom or settings, so if users defined "mirrorOf" in settings.xml, even defined banned repositories in pom.xml, it won't be detected.
+
++---+
+	<mirrors>
+	 <mirror>
+	   <id>nexus</id>
+	   <mirrorOf>*</mirrorOf>
+	   <url>http://.../nexus/..</url>
+	 </mirror>
+	</mirrors>
++---+ 

--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -57,6 +57,8 @@ Standard Rules
 
   * {{{./requireNoRepositories.html}requireNoRepositories}} - enforces to not include repositories.
 
+  * {{{./bannedRepositories.html}bannedRepositories}} - enforces to not include banned repositories.
+
   * {{{./requireOS.html}requireOS}} - enforces the OS / CPU Architecture.
 
   * {{{./requirePluginVersions.html}requirePluginVersions}} - enforces that all plugins have a specified version.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockProject.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockProject.java
@@ -100,6 +100,9 @@ public class MockProject
 
     /** The plugin artifact repositories. */
     private List pluginArtifactRepositories;
+    
+    /** The artifact repositories. */
+    private List artifactRepositories;
 
     // private ArtifactRepository releaseArtifactRepository;
 
@@ -298,7 +301,7 @@ public class MockProject
      */
     public void setRemoteArtifactRepositories( List list )
     {
-
+        this.artifactRepositories = list;
     }
 
     /*
@@ -308,7 +311,7 @@ public class MockProject
      */
     public List getRemoteArtifactRepositories()
     {
-        return Collections.singletonList( "" );
+        return artifactRepositories;
     }
 
     /*

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
@@ -1,0 +1,159 @@
+package org.apache.maven.plugins.enforcer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.DefaultArtifactRepository;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.codehaus.plexus.PlexusTestCase;
+
+/**
+ * Test the "banned repositories" rule.
+ * 
+ * @author <a href="mailto:wangyf2010@gmail.com">Simon Wang</a>
+ */
+public class TestBannedRepositories
+    extends PlexusTestCase
+{
+    private EnforcerRuleHelper helper;
+
+    private BannedRepositories rule;
+
+    private MockProject project;
+
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        rule = new BannedRepositories();
+        rule.setMessage( "my message" );
+
+        project = new MockProject();
+        project.setGroupId( "org.apache.maven.plugins.enforcer.test" );
+        project.setVersion( "1.0-SNAPSHOT" );
+
+        helper = EnforcerTestUtils.getHelper( project );
+    }
+
+    public void testNoCheckRules()
+        throws EnforcerRuleException
+    {
+        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
+        List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
+        repos.add( repo1 );
+
+        project.setRemoteArtifactRepositories( repos );
+        project.setPluginArtifactRepositories( repos );
+
+        rule.execute( helper );
+    }
+
+    public void testBannedRepositories()
+    {
+        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
+        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
+        DefaultArtifactRepository repo3 = new DefaultArtifactRepository( "repo1", "http://repo2/test", null );
+        List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
+        repos.add( repo1 );
+        repos.add( repo2 );
+        repos.add( repo3 );
+
+        project.setRemoteArtifactRepositories( repos );
+        project.setPluginArtifactRepositories( repos );
+
+        List<String> bannedRepositories = new ArrayList<String>();
+        String pattern1 = "http://repo1/*";
+
+        bannedRepositories.add( pattern1 );
+
+        rule.setBannedRepositories( bannedRepositories );
+
+        try
+        {
+            rule.execute( helper );
+            fail( "should throw exception" );
+        }
+        catch ( EnforcerRuleException e )
+        {
+        }
+
+    }
+
+    public void testAllowedRepositoriesAllOK()
+        throws EnforcerRuleException
+    {
+        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
+        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
+
+        List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
+        repos.add( repo1 );
+        repos.add( repo2 );
+
+        project.setRemoteArtifactRepositories( repos );
+        project.setPluginArtifactRepositories( repos );
+
+        List<String> bannedRepositories = new ArrayList<String>();
+        String pattern1 = "http://repo1/*";
+
+        bannedRepositories.add( pattern1 );
+
+        rule.setAllowedRepositories( bannedRepositories );
+        rule.setAllowedPluginRepositories( bannedRepositories );
+
+        rule.execute( helper );
+    }
+
+    public void testAllowedRepositoriesException()
+    {
+        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
+        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
+        DefaultArtifactRepository repo3 = new DefaultArtifactRepository( "repo1", "http://repo2/test", null );
+        List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
+        repos.add( repo1 );
+        repos.add( repo2 );
+        repos.add( repo3 );
+
+        project.setRemoteArtifactRepositories( repos );
+        project.setPluginArtifactRepositories( repos );
+
+        List<String> patterns = new ArrayList<String>();
+        String pattern1 = "http://repo1/*";
+
+        patterns.add( pattern1 );
+
+        rule.setAllowedPluginRepositories( patterns );
+        rule.setAllowedRepositories( patterns );
+
+        try
+        {
+            rule.execute( helper );
+            fail( "should throw exception" );
+        }
+        catch ( EnforcerRuleException e )
+        {
+        }
+
+    }
+}


### PR DESCRIPTION
There are use cases that need to ban specified repositories.
Ex. one enterprise migrate their repositories from old one to new one.
But some users still use old settings.xml or some projects' pom.xml still have old repositories.

What this rule did:
1. bannedRepositories: user could add banned repositories and support wildcard "*" to simplify user's usage.
2. allowedRepositories: that's simpler and useful for enterprise users.
