### PR TITLE
[MENFORCER-234]  Fix redirected link on plugin's website

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <name>Apache Maven Enforcer</name>
   <description>Enforcer is a build rule execution framework.</description>
-  <url>http://maven.apache.org/enforcer</url>
+  <url>http://maven.apache.org/enforcer/</url>
   <inceptionYear>2007</inceptionYear>
 
   <prerequisites>


### PR DESCRIPTION
Fix link according to [MENFORCER-234](https://issues.apache.org/jira/browse/MENFORCER-234)

After adding slash at the end, the link for maven enforcer plugin is:
http://maven.apache.org/enforcer/maven-enforcer-plugin/

and the link is reported as direct.
