### PR TITLE
[MENFORCER-273] Adding RequireUpperBoundDeps.excludes option

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
@@ -65,6 +65,13 @@ public class RequireUpperBoundDeps
     private boolean uniqueVersions;
 
     /**
+     * Dependencies to ignore.
+     *
+     * @since TBD
+     */
+    private List<String> excludes = null;
+
+    /**
      * Set to {@code true} if timestamped snapshots should be used.
      * 
      * @param uniqueVersions 
@@ -73,6 +80,15 @@ public class RequireUpperBoundDeps
     public void setUniqueVersions( boolean uniqueVersions )
     {
         this.uniqueVersions = uniqueVersions;
+    }
+
+    /**
+     * Sets dependencies to exclude.
+     * @param excludes a list of {@code groupId:artifactId} names
+     */
+    public void setExcludes( List<String> excludes )
+    {
+        this.excludes = excludes;
     }
 
     // CHECKSTYLE_OFF: LineLength
@@ -159,7 +175,16 @@ public class RequireUpperBoundDeps
         List<String> errorMessages = new ArrayList<String>( conflicts.size() );
         for ( List<DependencyNode> conflict : conflicts )
         {
-            errorMessages.add( buildErrorMessage( conflict ) );
+            Artifact artifact = conflict.get( 0 ).getArtifact();
+            String groupArt = artifact.getGroupId() + ":" + artifact.getArtifactId();
+            if ( excludes != null && excludes.contains( groupArt ) )
+            {
+                log.info( "Ignoring requireUpperBoundDeps in " + groupArt );
+            }
+            else
+            {
+                errorMessages.add( buildErrorMessage( conflict ) );
+            }
         }
         return errorMessages;
     }

--- a/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
+++ b/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
@@ -104,6 +104,11 @@ and
                 <requireUpperBoundDeps>
                   <!-- 'uniqueVersions' (default:false) can be set to true if you want to compare the timestamped SNAPSHOTs  -->
                   <!-- <uniqueVersions>true</uniqueVersions> -->
+                  <!-- If you wish to ignore certain cases:
+                  <excludes>
+                    <exclude>com.google.guava:guava</exclude>
+                  </excludes>
+                  -->
                 </requireUpperBoundDeps>
               </rules>
             </configuration>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/module/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>TestParent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>TestModule</artifactId>
+  <version>1.1-SNAPSHOT</version>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+  <artifactId>menforcer128</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_api</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_classic</artifactId>
+      <version>0.9.9</version>
+      <!-- Depends on org.apache.maven.plugins.enforcer.its:menforcer128_api:1.5.0 -->
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>org.apache.maven.plugins.enforcer.its:menforcer128_api</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-deps_ignored/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def LS = System.getProperty( "line.separator" )
+File buildLog = new File( basedir, 'build.log' )
+
+assert buildLog.text.contains( 'Ignoring requireUpperBoundDeps in org.apache.maven.plugins.enforcer.its:menforcer128_api' )


### PR DESCRIPTION
[MENFORCER-273](https://issues.apache.org/jira/browse/MENFORCER-273)

Needed to implement [JENKINS-41631](https://issues.jenkins-ci.org/browse/JENKINS-41631): there are certain known cases (that for various reasons cannot be fixed any time in the near future) where a dependency is older than a transitive version, yet this has been manually confirmed as acceptable, and we wish to enforce the ban for everything else. Analogous to exclude options on various other rules.

@reviewbybees for my colleages