### PR TITLE
MENFORCER-274 : Add check for version 9 in RequireJavaVersion

### DIFF
--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
@@ -60,6 +60,7 @@ public class TestRequireJavaVersion
         assertThat( RequireJavaVersion.normalizeJDKVersion( "1.6.0-dp" ) ).isEqualTo( "1.6.0" );
         assertThat( RequireJavaVersion.normalizeJDKVersion( "1.6.0-dp2" ) ).isEqualTo( "1.6.0-2" );
         assertThat( RequireJavaVersion.normalizeJDKVersion( "1.8.0_73" ) ).isEqualTo( "1.8.0-73" );
+        assertThat( RequireJavaVersion.normalizeJDKVersion( "9" ) ).isEqualTo( "9" );
 
     }
 


### PR DESCRIPTION
Adds an explicit regression check for Java-9 in the RequireJavaVersion test.

Note, the test already succeeds, this is just ensuring that it will keep succeeding in future.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>