### PR TITLE
MENFORCER-276 - Support ignoring dependency scopes in RequireUpperBoundDeps

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
@@ -71,7 +71,7 @@ public class RequireUpperBoundDeps
     private List<String> excludes = null;
     
     /**
-     * If {@code true}, upper bounds from test dependencies will be ignored.
+     * Dependency scopes to ignore.
      * 
      * @since TBD
      */

--- a/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
+++ b/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
@@ -109,6 +109,11 @@ and
                     <exclude>com.google.guava:guava</exclude>
                   </excludes>
                   -->
+                  <!-- If you wish to ignore certain dependency scopes:
+                  <ignoreDependencyScopes>
+                    <scope>test</scope>
+                  </ignoreDependencyScopes>
+                  -->
                 </requireUpperBoundDeps>
               </rules>
             </configuration>

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
@@ -121,7 +121,19 @@ public final class EnforcerTestUtils
      * @param mockExpression the mock expression
      * @return the helper
      */
-    public static EnforcerRuleHelper getHelper( MavenProject project, boolean mockExpression )
+    public static EnforcerRuleHelper getHelper( MavenProject project, boolean mockExpression ) {
+        return getHelper(project, mockExpression, null);
+    }
+    
+    /**
+     * Gets the helper.
+     *
+     * @param project the project
+     * @param mockExpression the mock expression
+     * @param container Plexus container to be used. If {@code null}, a default Maven Session one will be used.
+     * @return the helper
+     */
+    public static EnforcerRuleHelper getHelper( MavenProject project, boolean mockExpression, PlexusContainer container)
     {
         MavenSession session = getMavenSession();
         ExpressionEvaluator eval;
@@ -136,7 +148,7 @@ public final class EnforcerTestUtils
             session.setCurrentProject( project );
             eval = new PluginParameterExpressionEvaluator( session, mockExecution );
         }
-        return new DefaultEnforcementRuleHelper( session, eval, new SystemStreamLog(), null );
+        return new DefaultEnforcementRuleHelper( session, eval, new SystemStreamLog(), container );
     }
 
     /**

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireUpperBoundDeps.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireUpperBoundDeps.java
@@ -107,6 +107,7 @@ public class TestRequireUpperBoundDeps {
         TestEnforcerRuleUtils.execute(rule, helper, false);
     }
     
+    // MENFORCER-273
     @Test
     public void testShouldPassForOlderDependencyIfExcluded() throws Exception {
         dependencyTree.addDependency(library1_10);
@@ -116,6 +117,28 @@ public class TestRequireUpperBoundDeps {
                 
         rule.setExcludes(Arrays.asList("my:library1"));
         TestEnforcerRuleUtils.execute(rule, helper, false);
+    }
+    
+    // MENFORCER-276
+    @Test
+    public void testShouldPassIfTestArtifactsAreIgnored() throws Exception {
+        dependencyTree.addDependency(library1_10);
+        
+        library2_10.setScope("test");
+        DependencyNode n = new DependencyNode(library2_10);
+        n.addChild(new DependencyNode(library1_20));
+        dependencyTree.addDependency(n);
+                
+        rule.setIgnoreDependencyScopes(Arrays.asList("test"));
+        TestEnforcerRuleUtils.execute(rule, helper, false);
+    }
+    
+    // MENFORCER-276
+    @Test
+    public void testShouldFailIfWrongScopeIsIgnored() throws Exception {
+        testShouldPassIfTestArtifactsAreIgnored();   
+        rule.setIgnoreDependencyScopes(Arrays.asList("provided"));
+        TestEnforcerRuleUtils.execute(rule, helper, true);
     }
     
     // TODO: make it a generic class

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireUpperBoundDeps.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireUpperBoundDeps.java
@@ -1,0 +1,164 @@
+package org.apache.maven.plugins.enforcer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactCollector;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugin.testing.ArtifactStubFactory;
+import org.apache.maven.plugins.enforcer.utils.TestEnforcerRuleUtils;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.tree.DependencyNode;
+import org.apache.maven.shared.dependency.tree.DependencyTree;
+import org.apache.maven.shared.dependency.tree.DependencyTreeBuilder;
+import org.apache.maven.shared.dependency.tree.DependencyTreeBuilderException;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.junit.Before;
+import org.junit.Test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Tests for {@link RequireUpperBoundDeps}.
+ * @author Oleg Nenashev
+ */
+public class TestRequireUpperBoundDeps {
+    
+    private MavenProject project;
+
+    private EnforcerRuleHelper helper;
+
+    private ArtifactStubFactory factory;
+
+    private RequireUpperBoundDeps rule;
+    private MockDependencyTreeBuilder dependencyTree;
+    
+    Artifact library1_10, library1_20, library2_10;
+    
+    @Before
+    public void before() throws Exception
+    {
+        PlexusContainer c = new DefaultPlexusContainer();
+        dependencyTree = new MockDependencyTreeBuilder();
+        factory = new ArtifactStubFactory();
+        
+        project = new MockProject();
+        project.setArtifact(factory.createArtifact("my", "project", "1.0"));
+        library1_10 = factory.createArtifact("my", "library1", "1.0");
+        library1_20 = factory.createArtifact("my", "library1", "2.0");
+        library2_10 = factory.createArtifact("my", "library2", "1.0");
+        
+        helper = EnforcerTestUtils.getHelper(project, false, c);
+        helper.getContainer().addComponent(dependencyTree, DependencyTreeBuilder.class.getName());
+        
+        rule = new RequireUpperBoundDeps();  
+    }
+    
+    @Test
+    public void testShouldPassForSameDependencies() throws Exception {
+        dependencyTree.addDependency(library1_10);
+        DependencyNode n = new DependencyNode(library2_10);
+        n.addChild(new DependencyNode(library1_10));
+        dependencyTree.addDependency(n);
+                
+        TestEnforcerRuleUtils.execute(rule, helper, false);
+    }
+    
+    @Test
+    public void testShouldFailForNewerDependencies() throws Exception {
+        dependencyTree.addDependency(library1_10);
+        DependencyNode n = new DependencyNode(library2_10);
+        n.addChild(new DependencyNode(library1_20));
+        dependencyTree.addDependency(n);
+                
+        TestEnforcerRuleUtils.execute(rule, helper, true);
+    }
+    
+    @Test
+    public void testShouldPassForOlderDependencies() throws Exception {
+        dependencyTree.addDependency(library1_20);
+        DependencyNode n = new DependencyNode(library2_10);
+        n.addChild(new DependencyNode(library1_10));
+        dependencyTree.addDependency(n);
+                
+        TestEnforcerRuleUtils.execute(rule, helper, false);
+    }
+    
+    @Test
+    public void testShouldPassForOlderDependencyIfExcluded() throws Exception {
+        dependencyTree.addDependency(library1_10);
+        DependencyNode n = new DependencyNode(library2_10);
+        n.addChild(new DependencyNode(library1_20));
+        dependencyTree.addDependency(n);
+                
+        rule.setExcludes(Arrays.asList("my:library1"));
+        TestEnforcerRuleUtils.execute(rule, helper, false);
+    }
+    
+    // TODO: make it a generic class
+    private static final class MockDependencyTreeBuilder implements DependencyTreeBuilder {
+
+        List<DependencyNode> dependencies = new ArrayList<DependencyNode>();    
+       
+        public void addDependency(DependencyNode node) {
+            dependencies.add(node);
+        }
+        
+        public void addDependency(Artifact artifact) {
+            dependencies.add(new DependencyNode(artifact));
+        }
+        
+        @Override
+        public DependencyNode buildDependencyTree(MavenProject project, ArtifactRepository repository, 
+                ArtifactFactory factory, ArtifactMetadataSource metadataSource, ArtifactFilter filter, 
+                ArtifactCollector collector) throws DependencyTreeBuilderException {
+            DependencyNode root = new DependencyNode(project.getArtifact());
+            for (DependencyNode child : dependencies) {
+                root.addChild(child);
+            }
+            return root;
+        }
+        
+        @Override
+        public DependencyTree buildDependencyTree(MavenProject project, ArtifactRepository repository, 
+                ArtifactFactory factory, ArtifactMetadataSource metadataSource, 
+                ArtifactCollector collector) throws DependencyTreeBuilderException {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+
+        @Override
+        public DependencyNode buildDependencyTree(MavenProject project) throws DependencyTreeBuilderException {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public DependencyNode buildDependencyTree(MavenProject arg0, ArtifactRepository arg1, ArtifactFilter arg2) throws DependencyTreeBuilderException {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+        
+    }
+}

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult=failure

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/module/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>TestParent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>TestModule</artifactId>
+  <version>1.1-SNAPSHOT</version>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+  <artifactId>menforcer128</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_api</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_classic</artifactId>
+      <version>0.9.9</version>
+      <scope>test</scope>
+      <!-- Depends on org.apache.maven.plugins.enforcer.its:menforcer128_api:1.5.0 -->
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <RequireUpperBoundDeps/>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.maven.plugins.enforcer.its</groupId>
-  <artifactId>menforcer128</artifactId>
+  <artifactId>menforcer276/artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <dependencies>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_failure/verify.groovy
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def LS = System.getProperty( "line.separator" )
+File buildLog = new File( basedir, 'build.log' )
+
+assert buildLog.text.contains( 'Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:' )
+def message = 
+'Require upper bound dependencies error for org.apache.maven.plugins.enforcer.its:menforcer128_api:1.4.0 paths to dependency are:'+LS+
+'+-org.apache.maven.plugins.enforcer.its:menforcer128:1.0-SNAPSHOT'+LS+
+'  +-org.apache.maven.plugins.enforcer.its:menforcer128_api:1.4.0'+LS+
+'and'+LS+
+'+-org.apache.maven.plugins.enforcer.its:menforcer128:1.0-SNAPSHOT'+LS+
+'  +-org.apache.maven.plugins.enforcer.its:menforcer128_classic:0.9.9'+LS+
+'    +-org.apache.maven.plugins.enforcer.its:menforcer128_api:1.5.0'+LS
+assert buildLog.text.contains( message )
+

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/module/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>TestParent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>TestModule</artifactId>
+  <version>1.1-SNAPSHOT</version>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License. 
+  *
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+  <artifactId>menforcer128</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_api</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_classic</artifactId>
+      <version>0.9.9</version>
+      <scope>test</scope>
+      <!-- Depends on org.apache.maven.plugins.enforcer.its:menforcer128_api:1.5.0 -->
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps>
+                  <ignoreDependencyScopes>
+                    <scope>test</scope>
+                  </ignoreDependencyScopes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-upper-bound-test-deps_ignored/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.maven.plugins.enforcer.its</groupId>
-  <artifactId>menforcer128</artifactId>
+  <artifactId>menforcer276</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <dependencies>


### PR DESCRIPTION
We have recently adopted `RequireUpperBoundDeps` in the Jenkins project (https://github.com/jenkinsci/plugin-pom/pull/67). In order to implement it, Jesse Glick added a support of ignoring particular dependencies in [MENFORCER-273](https://issues.apache.org/jira/browse/MENFORCER-273).

Sometimes we declare dependencies between plugins for testing purposes (scope=test), and in such case RequireUpperBoundDeps fails the build if there is a test dependency conflicting with the main code. Although it may cause instability of tests (including false positive results), it does not really impact the distributable package in our case.

I propose to add another option for filtering of dependency scopes. This pull request also adds some unit tests for `RequireUpperBoundDeps`. Previously it had integration tests only.

https://issues.apache.org/jira/browse/MENFORCER-276

@reviewbybees @jglick @stephenc 