### PR TITLE
Fixed wrong page title for Dependency Convergence

### DIFF
--- a/enforcer-rules/src/site/apt/dependencyConvergence.apt.vm
+++ b/enforcer-rules/src/site/apt/dependencyConvergence.apt.vm
@@ -16,7 +16,7 @@
  ~~ under the License.
 
  -----
- Comparing against a specific artifact
+ Dependency Convergence
  -----
  -----
  2008-09-13


### PR DESCRIPTION
Check page title here:
http://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html