### PR TITLE
[MENFORCER-281] added IT to show the issue.

### DIFF
--- a/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals = install -Drevision=0.10.0-SNAPSHOT

--- a/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/menforcer281-module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/menforcer281-module/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.its.enforcer</groupId>
+    <artifactId>menforcer281-parent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>menforcer281-module</artifactId>
+  <packaging>pom</packaging>
+
+  <description>
+  </description>
+
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-plugin-versions-mm-ci-friendly/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>menforcer281-parent</artifactId>
+  <version>${revision}</version>
+  <packaging>pom</packaging>
+
+  <description>
+  </description>
+  
+  <properties>
+    <revision>0.0.1-SNAPSHOT</revision>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.5.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>@project.version@</version>
+          <executions>
+            <execution>
+              <id>test</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requirePluginVersions>
+                    <banSnapshots>false</banSnapshots>
+                  </requirePluginVersions>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <modules>
+    <module>menforcer281-module</module>
+  </modules>
+</project>


### PR DESCRIPTION
Added an IT to demonstrate [MENFORCER-281](https://issues.apache.org/jira/browse/MENFORCER-281)

Fails with the following which is slightly different to what is observed in the real project, but is at least a starter for 10

```
[ERROR] /org/apache/maven/its/enforcer/menforcer281-parent/$%7Brevision%7D/menforcer281-parent-$%7Brevision%7D.pom
java.lang.IllegalArgumentException: Illegal character in path at index 110: https://XXXXX/org/apache/maven/its/enforcer/m
enforcer281-parent/${revision}/maven-metadata.xml
        at java.net.URI.create(URI.java:852)
        at org.apache.maven.wagon.providers.http.httpclient.client.methods.HttpGet.<init>(HttpGet.java:69)
        at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:972)
        at org.apache.maven.wagon.providers.http.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:962)
        at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:126)
        at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
        at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
        at org.apache.maven.repository.legacy.DefaultWagonManager.getRemoteFile(DefaultWagonManager.java:413)
        at org.apache.maven.repository.legacy.DefaultWagonManager.getArtifactMetadata(DefaultWagonManager.java:233)
        at org.apache.maven.artifact.repository.metadata.DefaultRepositoryMetadataManager.resolve(DefaultRepositoryMetadataManager.java:132)
        at org.apache.maven.artifact.repository.metadata.DefaultRepositoryMetadataManager.resolve(DefaultRepositoryMetadataManager.java:71)
        at org.codehaus.mojo.mrm.maven.ProxyArtifactStore.getMetadata(ProxyArtifactStore.java:480)
        at org.codehaus.mojo.mrm.maven.ProxyArtifactStore.getMetadataLastModified(ProxyArtifactStore.java:536)
        at org.codehaus.mojo.mrm.impl.maven.CompositeArtifactStore.getMetadataLastModified(CompositeArtifactStore.java:339)
        at org.codehaus.mojo.mrm.impl.maven.ArtifactStoreFileSystem.listEntries(ArtifactStoreFileSystem.java:147)
        at org.codehaus.mojo.mrm.impl.digest.AutoDigestFileSystem.listEntries(AutoDigestFileSystem.java:100)
        at org.codehaus.mojo.mrm.api.BaseFileSystem.get(BaseFileSystem.java:89)
        at org.codehaus.mojo.mrm.impl.digest.AutoDigestFileSystem.get(AutoDigestFileSystem.java:185)
        at org.codehaus.mojo.mrm.servlet.FileSystemServlet.doGet(FileSystemServlet.java:157)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
        at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:487)
        at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:362)
        at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:181)
        at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:712)
        at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:139)
        at org.mortbay.jetty.Server.handle(Server.java:313)
        at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:506)
        at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:830)
        at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:514)
        at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:211)
        at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:381)
        at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:227)
        at org.mortbay.thread.BoundedThreadPool$PoolThread.run(BoundedThreadPool.java:442)
Caused by: java.net.URISyntaxException: Illegal character in path at index 110: https://XXXXXX/org/apache/maven/its/enforc
er/menforcer281-parent/${revision}/maven-metadata.xml
        at java.net.URI$Parser.fail(URI.java:2848)
        at java.net.URI$Parser.checkChars(URI.java:3021)
        at java.net.URI$Parser.parseHierarchical(URI.java:3105)
        at java.net.URI$Parser.parse(URI.java:3053)
        at java.net.URI.<init>(URI.java:588)
        at java.net.URI.create(URI.java:850)
        ... 33 more
[INFO] ..FAILED (5.7 s)
```