### PR TITLE
[MENFORCER-320] RequireProfileIdsExist check must not fail if no profiles are used

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireProfileIdsExist.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireProfileIdsExist.java
@@ -64,13 +64,13 @@ public class RequireProfileIdsExist extends AbstractNonCacheableEnforcerRule
             for ( org.apache.maven.settings.Profile profile : session.getSettings().getProfiles() )
             {
                 profileIds.remove( profile.getId() );
-                
-                if ( profileIds.isEmpty() )
-                {
-                    return;
-                }
             }
-            
+
+            if ( profileIds.isEmpty() )
+            {
+                return;
+            }
+
             StringBuilder sb = new StringBuilder();
             if ( profileIds.size() > 1 )
             {

--- a/enforcer-rules/src/site/apt/requireProfileIdsExist.apt.vm
+++ b/enforcer-rules/src/site/apt/requireProfileIdsExist.apt.vm
@@ -16,7 +16,7 @@
  ~~ under the License.
 
  -----
- Require Upper Bound Dependencies
+ Require Existence of Profiles Specified on the Commandline
  -----
  -----
  2017-09-25


### PR DESCRIPTION
Fixes RequireProfileIdsExist behavior if there are no profiles on the command line nor in the pom.xml. Fixes breadcrumbs on the plugin's site for the RequireProfileIdsExist rule page.

I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
