### PR TITLE
[MENFORCER-322] - requireProfileIdsExist triggers if profile is defined at parent

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireProfileIdsExist.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireProfileIdsExist.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.util.StringUtils;
  * Ensure that all profiles mentioned on the commandline do exist. 
  * 
  * @author Robert Scholte
+ * @author Gabriel Belingueres
  */
 public class RequireProfileIdsExist extends AbstractNonCacheableEnforcerRule
 {
@@ -43,24 +44,32 @@ public class RequireProfileIdsExist extends AbstractNonCacheableEnforcerRule
         try
         {
             MavenSession session = (MavenSession) helper.evaluate( "${session}" );
-            
+
             List<String> profileIds = new ArrayList<String>();
             profileIds.addAll( session.getProjectBuildingRequest().getActiveProfileIds() );
             profileIds.addAll( session.getProjectBuildingRequest().getInactiveProfileIds() );
-            
+
             for ( MavenProject project : session.getProjects() )
             {
-                for ( org.apache.maven.model.Profile profile : project.getModel().getProfiles() )
+                // iterate over all parents
+                MavenProject currentProject = project;
+                do
                 {
-                    profileIds.remove( profile.getId() );
-                    
-                    if ( profileIds.isEmpty() )
+                    for ( org.apache.maven.model.Profile profile : currentProject.getModel().getProfiles() )
                     {
-                        return;
+                        profileIds.remove( profile.getId() );
+
+                        if ( profileIds.isEmpty() )
+                        {
+                            return;
+                        }
                     }
+
+                    currentProject = currentProject.getParent();
                 }
+                while ( currentProject != null );
             }
-            
+
             for ( org.apache.maven.settings.Profile profile : session.getSettings().getProfiles() )
             {
                 profileIds.remove( profile.getId() );
@@ -81,7 +90,7 @@ public class RequireProfileIdsExist extends AbstractNonCacheableEnforcerRule
                 sb.append( "The requested profile doesn't exist: " );
             }
             sb.append( StringUtils.join( profileIds.iterator(), ", " ) );
-            
+
             throw new EnforcerRuleException( sb.toString() );
         }
         catch ( ExpressionEvaluationException e )

--- a/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/MENFORCER-322-module/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/MENFORCER-322-module/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- MENFORCER-322 -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.apache.maven.its.enforcer</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <relativePath>..</relativePath>
+  </parent>
+  
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>menforcer-322-module</artifactId>
+  <version>1.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <RequireProfileIdsExist/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <profiles>
+    <profile>
+      <id>b</id>
+    </profile>
+  </profiles>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/invoker.properties
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# MENFORCER-322
+
+# test building the top level project 
+invoker.goals.1 = clean compile
+invoker.profiles.1 = a,b
+
+# test building the module
+invoker.project.2 = MENFORCER-322-module
+invoker.goals.2 = clean compile
+invoker.profiles.2 = a,b

--- a/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- MENFORCER-322 -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <RequireProfileIdsExist/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <modules>
+    <module>MENFORCER-322-module</module>
+  </modules>
+  
+  <profiles>
+    <profile>
+      <id>a</id>
+    </profile>
+  </profiles>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-profile-id-exist_defined_in_parent/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def buildLog = new File( basedir, 'build.log' )
+assert !( buildLog.text.contains( "The requested profile doesn't exist: a" ) )
+assert !( buildLog.text.contains( "The requested profile doesn't exist: b" ) )


### PR DESCRIPTION
Fixed iterating over parent poms. Added IT.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

