### PR TITLE
[MENFORCER-323] - Improve output of "Some plugins are missing valid versions" error

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequirePluginVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequirePluginVersions.java
@@ -265,7 +265,7 @@ public class RequirePluginVersions
                 newMsg.append( "Some plugins are missing valid versions:" );
                 if ( banLatest || banRelease || banSnapshots || banTimestamps )
                 {
-                    newMsg.append( "(" );
+                    newMsg.append( " (" );
                     if ( banLatest )
                     {
                         newMsg.append( "LATEST " );
@@ -278,8 +278,9 @@ public class RequirePluginVersions
                     {
                         newMsg.append( "SNAPSHOT " );
                     }
-                    newMsg.append( "are not allowed )\n" );
+                    newMsg.append( "are not allowed)" );
                 }
+                newMsg.append( "\n" );
                 for ( Plugin plugin : failures )
                 {
                     newMsg.append( plugin.getGroupId() );

--- a/maven-enforcer-plugin/src/it/projects/require-plugin-versions-ci/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-plugin-versions-ci/verify.groovy
@@ -18,4 +18,4 @@
  */
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.text.contains( '[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:' )
-assert buildLog.text.contains( 'Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )' )
+assert buildLog.text.contains( 'Some plugins are missing valid versions: (LATEST RELEASE SNAPSHOT are not allowed)' )


### PR DESCRIPTION

The old output could be:
```
Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )
org.apache.maven.plugins:maven-release-plugin.  The version currently in use is 2.5.3
org.apache.maven.plugins:maven-resources-plugin.        The version currently in use is 3.0.2
```

If that if branch wasn't taken, then there wouldn't even be a newline, which would make the output even uglier.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

