### PR TITLE
[MENFORCER-332] Dependency graph performance fix

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>maven-common-artifact-filters</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-dependency-tree</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
@@ -84,14 +88,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-dependency-tree</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -110,6 +110,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/AbstractBanDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/AbstractBanDependencies.java
@@ -105,7 +105,7 @@ public abstract class AbstractBanDependencies
     protected Set<Artifact> getDependenciesToCheck( EnforcerRuleHelper helper ) throws EnforcerRuleException
     {
         Set<Artifact> dependencies = null;
-        DependencyNode node = graphLookup.getDependencyGraph( helper );
+        DependencyNode node = graphLookup.getTransformedDependencyGraph( helper );
         if ( searchTransitive )
         {
             dependencies = getAllDescendants( node );

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -161,7 +161,7 @@ public class BanTransitiveDependencies
             throw new EnforcerRuleException( "Unable to lookup DependencyGraphLookup: ", e );
         }
 
-        DependencyNode rootNode = graphLookup.getDependencyGraph( helper );
+        DependencyNode rootNode = graphLookup.getTransformedDependencyGraph( helper );
 
         String message = getMessage();
         StringBuilder generatedMessage = null;

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanTransitiveDependencies.java
@@ -27,7 +27,9 @@ import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyGraphBuilder;
@@ -158,7 +160,11 @@ public class BanTransitiveDependencies
         try
         {
             MavenProject project = (MavenProject) helper.evaluate( "${project}" );
-            rootNode = createDependencyGraphBuilder().buildDependencyGraph( project, null );
+            ProjectBuildingRequest sessionRequest =
+                (ProjectBuildingRequest) helper.evaluate( "${session.projectBuildingRequest}" );
+            ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest( sessionRequest );
+            buildingRequest.setProject( project );
+            rootNode = createDependencyGraphBuilder().buildDependencyGraph( buildingRequest, null );
         }
         catch ( Exception e )
         {

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedPlugins.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedPlugins.java
@@ -22,7 +22,10 @@ package org.apache.maven.plugins.enforcer;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * This rule checks that lists of plugins are not included.
@@ -33,9 +36,17 @@ public class BannedPlugins
     extends BannedDependencies
 {
     @Override
-    protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
+    protected Set<Artifact> getDependenciesToCheck( EnforcerRuleHelper helper ) throws EnforcerRuleException
     {
-        return buildingRequest.getProject().getPluginArtifacts();
+        try
+        {
+            MavenProject project = helper.getComponent( MavenProject.class );
+            return project.getPluginArtifacts();
+        }
+        catch ( ComponentLookupException e )
+        {
+            throw new EnforcerRuleException( "Could not load MavenProject: ", e );
+        }
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedPlugins.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedPlugins.java
@@ -22,7 +22,7 @@ package org.apache.maven.plugins.enforcer;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
 
 /**
  * This rule checks that lists of plugins are not included.
@@ -33,9 +33,9 @@ public class BannedPlugins
     extends BannedDependencies
 {
     @Override
-    protected Set<Artifact> getDependenciesToCheck( MavenProject project )
+    protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
     {
-        return project.getPluginArtifacts();
+        return buildingRequest.getProject().getPluginArtifacts();
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
@@ -26,10 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactCollector;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -37,11 +33,13 @@ import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.dependency.tree.DependencyNode;
-import org.apache.maven.shared.dependency.tree.DependencyTreeBuilder;
-import org.apache.maven.shared.dependency.tree.DependencyTreeBuilderException;
-import org.apache.maven.shared.dependency.tree.traversal.DependencyNodeVisitor;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
@@ -91,7 +89,7 @@ public class RequireUpperBoundDeps
     // CHECKSTYLE_OFF: LineLength
     /**
      * Uses the {@link EnforcerRuleHelper} to populate the values of the
-     * {@link DependencyTreeBuilder#buildDependencyTree(MavenProject, ArtifactRepository, ArtifactFactory, ArtifactMetadataSource, ArtifactFilter, ArtifactCollector)}
+     * {@link DependencyGraphBuilder#buildDependencyGraph(ProjectBuildingRequest, ArtifactFilter)}
      * factory method. <br/>
      * This method simply exists to hide all the ugly lookup that the {@link EnforcerRuleHelper} has to do.
      * 
@@ -105,18 +103,15 @@ public class RequireUpperBoundDeps
     {
         try
         {
+
+            ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
             MavenProject project = (MavenProject) helper.evaluate( "${project}" );
-            DependencyTreeBuilder dependencyTreeBuilder =
-                (DependencyTreeBuilder) helper.getComponent( DependencyTreeBuilder.class );
-            ArtifactRepository repository = (ArtifactRepository) helper.evaluate( "${localRepository}" );
-            ArtifactFactory factory = (ArtifactFactory) helper.getComponent( ArtifactFactory.class );
-            ArtifactMetadataSource metadataSource =
-                (ArtifactMetadataSource) helper.getComponent( ArtifactMetadataSource.class );
-            ArtifactCollector collector = (ArtifactCollector) helper.getComponent( ArtifactCollector.class );
+            buildingRequest.setProject( project );
+            DependencyGraphBuilder dependencyGraphBuilder =
+                helper.getComponent( DependencyGraphBuilder.class );
             ArtifactFilter filter = null; // we need to evaluate all scopes
             DependencyNode node =
-                dependencyTreeBuilder.buildDependencyTree( project, repository, factory, metadataSource, filter,
-                                                           collector );
+                dependencyGraphBuilder.buildDependencyGraph( buildingRequest, filter );
             return node;
         }
         catch ( ExpressionEvaluationException e )
@@ -127,9 +122,9 @@ public class RequireUpperBoundDeps
         {
             throw new EnforcerRuleException( "Unable to lookup a component " + e.getLocalizedMessage(), e );
         }
-        catch ( DependencyTreeBuilderException e )
+        catch ( DependencyGraphBuilderException e )
         {
-            throw new EnforcerRuleException( "Could not build dependency tree " + e.getLocalizedMessage(), e );
+            throw new EnforcerRuleException( "Could not build dependency graph " + e.getLocalizedMessage(), e );
         }
     }
 

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/DependencyGraphLookup.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/DependencyGraphLookup.java
@@ -1,0 +1,124 @@
+package org.apache.maven.plugins.enforcer.utils;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+/**
+ * Collects a dependency graph, and caches it for reuse by any rules in the same project.
+ */
+@Named
+@Singleton
+public class DependencyGraphLookup
+{
+    private ProjectBuildingRequest sessionRequest;
+    private DependencyGraphBuilder dependencyGraphBuilder;
+    private LoadingCache<MavenProject, DependencyNode> projectDependencyGraphCache = CacheBuilder.newBuilder()
+            .maximumSize( 128 )
+            .build( new CacheLoader<MavenProject, DependencyNode>()
+            {
+                @Override
+                public DependencyNode load( MavenProject project ) throws Exception
+                {
+                    return getDependencyGraph( project );
+                }
+            } );
+
+    private synchronized void init( EnforcerRuleHelper helper ) throws EnforcerRuleException
+    {
+        if ( dependencyGraphBuilder == null )
+        {
+            try
+            {
+                MavenSession session = helper.getComponent( MavenSession.class );
+                this.sessionRequest = session.getProjectBuildingRequest();
+            }
+            catch ( ComponentLookupException e )
+            {
+                throw new EnforcerRuleException( "Unable to load MavenSession: ", e );
+            }
+            try
+            {
+                this.dependencyGraphBuilder = helper.getComponent( DependencyGraphBuilder.class );
+            }
+            catch ( ComponentLookupException e )
+            {
+                throw new EnforcerRuleException( "Unable to load DependencyGraphBuilder: ", e );
+            }
+        }
+    }
+
+    public synchronized DependencyNode getDependencyGraph( EnforcerRuleHelper helper ) throws EnforcerRuleException
+    {
+        init( helper );
+        MavenProject project;
+        try
+        {
+            project = ( MavenProject ) helper.evaluate( "${project}" );
+        }
+        catch ( ExpressionEvaluationException e )
+        {
+            throw new EnforcerRuleException( "Unable to load MavenProject: ", e );
+        }
+        try
+        {
+            return projectDependencyGraphCache.get( project );
+        }
+        catch ( ExecutionException e )
+        {
+            Throwables.propagateIfInstanceOf( e.getCause(), EnforcerRuleException.class );
+            throw new EnforcerRuleException( "Unable to build DependencyNode graph: ", e.getCause() );
+        }
+    }
+
+    private DependencyNode getDependencyGraph( MavenProject project ) throws EnforcerRuleException
+    {
+        ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest( sessionRequest );
+        buildingRequest.setProject( project );
+        try
+        {
+            return dependencyGraphBuilder.buildDependencyGraph( buildingRequest, null );
+        }
+        catch ( DependencyGraphBuilderException e )
+        {
+            throw new EnforcerRuleException( "Unable to build DependencyNode graph: ", e );
+        }
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/DependencyVersionMap.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/DependencyVersionMap.java
@@ -26,8 +26,8 @@ import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.shared.dependency.tree.DependencyNode;
-import org.apache.maven.shared.dependency.tree.traversal.DependencyNodeVisitor;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
 
 /**
  * @author Brian Fox

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
@@ -21,16 +21,10 @@ package org.apache.maven.plugins.enforcer.utils;
 
 import java.util.List;
 
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * The Class EnforcerRuleUtils.
@@ -39,48 +33,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
  */
 public class EnforcerRuleUtils
 {
-
-    /** The factory. */
-    ArtifactFactory factory;
-
-    /** The resolver. */
-    ArtifactResolver resolver;
-
-    /** The local. */
-    ArtifactRepository local;
-
-    /** The remote repositories. */
-    List<ArtifactRepository> remoteRepositories;
-
-    /** The log. */
-    Log log;
-
-    /** The project. */
-    MavenProject project;
-
     private EnforcerRuleHelper helper;
-
-    /**
-     * Instantiates a new enforcer rule utils.
-     *
-     * @param theFactory the the factory
-     * @param theResolver the the resolver
-     * @param theLocal the the local
-     * @param theRemoteRepositories the the remote repositories
-     * @param project the project
-     * @param theLog the the log
-     */
-    public EnforcerRuleUtils( ArtifactFactory theFactory, ArtifactResolver theResolver, ArtifactRepository theLocal,
-                              List<ArtifactRepository> theRemoteRepositories, MavenProject project, Log theLog )
-    {
-        super();
-        this.factory = theFactory;
-        this.resolver = theResolver;
-        this.local = theLocal;
-        this.remoteRepositories = theRemoteRepositories;
-        this.log = theLog;
-        this.project = project;
-    }
 
     /**
      * Instantiates a new enforcer rule utils.
@@ -89,28 +42,7 @@ public class EnforcerRuleUtils
      */
     public EnforcerRuleUtils( EnforcerRuleHelper helper )
     {
-
         this.helper = helper;
-        // get the various expressions out of the
-        // helper.
-        try
-        {
-            factory = (ArtifactFactory) helper.getComponent( ArtifactFactory.class );
-            resolver = (ArtifactResolver) helper.getComponent( ArtifactResolver.class );
-            local = (ArtifactRepository) helper.evaluate( "${localRepository}" );
-            project = (MavenProject) helper.evaluate( "${project}" );
-            remoteRepositories = project.getRemoteArtifactRepositories();
-        }
-        catch ( ComponentLookupException e )
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch ( ExpressionEvaluationException e )
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
     }
 
     private void resolve( Plugin plugin )

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
@@ -29,6 +29,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
 
 public class BannedDependenciesTestSetup
 {
@@ -94,10 +95,11 @@ public class BannedDependenciesTestSetup
         {
             @SuppressWarnings( "unchecked" )
             @Override
-            protected Set<Artifact> getDependenciesToCheck( MavenProject project )
+            protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
             {
                 // the integration with dependencyGraphTree is verified with the integration tests
                 // for unit-testing
+                MavenProject project = buildingRequest.getProject();
                 return isSearchTransitive() ? project.getArtifacts() : project.getDependencyArtifacts();
             }
         };

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
@@ -29,7 +29,8 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+
 
 public class BannedDependenciesTestSetup
 {
@@ -95,17 +96,18 @@ public class BannedDependenciesTestSetup
         {
             @SuppressWarnings( "unchecked" )
             @Override
-            protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
+            protected Set<Artifact> getDependenciesToCheck( EnforcerRuleHelper helper ) throws EnforcerRuleException
             {
                 // the integration with dependencyGraphTree is verified with the integration tests
                 // for unit-testing
-                MavenProject project = buildingRequest.getProject();
-                return isSearchTransitive() ? project.getArtifacts() : project.getDependencyArtifacts();
+                try {
+                    MavenProject project = ( MavenProject ) helper.evaluate( "${project}" );
+                    return isSearchTransitive() ? project.getArtifacts() : project.getDependencyArtifacts();
+                } catch ( ExpressionEvaluationException e ) {
+                    throw new EnforcerRuleException( "Could not load MavenProject: ", e );
+                }
             }
         };
         return rule;
     }
-
-
 }
-

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
@@ -19,6 +19,7 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,9 +35,11 @@ import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.plugins.enforcer.utils.MockEnforcerExpressionEvaluator;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
-import org.sonatype.aether.RepositorySystemSession;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.RepositorySystemSession;
 
 /**
  * The Class EnforcerTestUtils.
@@ -52,9 +55,12 @@ public final class EnforcerTestUtils
      */
     public static MavenSession getMavenSession()
     {
-        PlexusContainer mock = mock( PlexusContainer.class );
+        PlexusContainer container = mock( PlexusContainer.class );
 
         MavenExecutionRequest mer = mock( MavenExecutionRequest.class );
+        ProjectBuildingRequest pbr = mock( ProjectBuildingRequest.class );
+        when( pbr.setRepositorySession( nullable( RepositorySystemSession.class ) ) ).thenReturn( pbr );
+        when( mer.getProjectBuildingRequest() ).thenReturn( pbr );
 
         Properties systemProperties = new Properties();
         systemProperties.put( "maven.version", "3.0" );
@@ -62,7 +68,15 @@ public final class EnforcerTestUtils
         when( mer.getSystemProperties() ).thenReturn( systemProperties );
 
         MavenExecutionResult meresult = mock( MavenExecutionResult.class );
-        return new MavenSession( mock, (RepositorySystemSession) null, mer, meresult );
+        MavenSession session = new MavenSession( container, null, mer, meresult );
+        try
+        {
+            when( container.lookup( MavenSession.class ) ).thenReturn( session );
+        }
+        catch (ComponentLookupException ignored)
+        {
+        }
+        return session;
     }
 
     /**

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockPlexusContainer.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockPlexusContainer.java
@@ -25,8 +25,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.maven.execution.RuntimeInformation;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.classworlds.ClassRealm;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
@@ -36,7 +36,6 @@ import org.codehaus.plexus.component.factory.ComponentInstantiationException;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
 import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
 import org.codehaus.plexus.configuration.PlexusConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
@@ -288,7 +288,7 @@ public class TestBannedDependencies
         }
 
         @Test
-        public void includeEverythingAndExcludeEverythign()
+        public void includeEverythingAndExcludeEverything()
             throws EnforcerRuleException
         {
             addIncludeExcludeAndRunRule( "*", "*" );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
@@ -23,7 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.DefaultArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.bridge.MavenRepositorySystem;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.codehaus.plexus.PlexusTestCase;
@@ -36,6 +37,7 @@ import org.codehaus.plexus.PlexusTestCase;
 public class TestBannedRepositories
     extends PlexusTestCase
 {
+    private DefaultRepositoryLayout defaultRepositoryLayout = new DefaultRepositoryLayout();
     private EnforcerRuleHelper helper;
 
     private BannedRepositories rule;
@@ -58,9 +60,9 @@ public class TestBannedRepositories
     }
 
     public void testNoCheckRules()
-        throws EnforcerRuleException
+            throws Exception
     {
-        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
+        ArtifactRepository repo1 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/", defaultRepositoryLayout , null, null);
         List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
         repos.add( repo1 );
 
@@ -70,11 +72,10 @@ public class TestBannedRepositories
         rule.execute( helper );
     }
 
-    public void testBannedRepositories()
-    {
-        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
-        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
-        DefaultArtifactRepository repo3 = new DefaultArtifactRepository( "repo1", "http://repo2/test", null );
+    public void testBannedRepositories() {
+        ArtifactRepository repo1 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/", defaultRepositoryLayout, null, null );
+        ArtifactRepository repo2 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/test", defaultRepositoryLayout, null, null );
+        ArtifactRepository repo3 = MavenRepositorySystem.createArtifactRepository( "repo2", "http://repo2/test", defaultRepositoryLayout, null, null );
         List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
         repos.add( repo1 );
         repos.add( repo2 );
@@ -104,8 +105,8 @@ public class TestBannedRepositories
     public void testAllowedRepositoriesAllOK()
         throws EnforcerRuleException
     {
-        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
-        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
+        ArtifactRepository repo1 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/", defaultRepositoryLayout, null, null );
+        ArtifactRepository repo2 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/test", defaultRepositoryLayout, null, null );
 
         List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
         repos.add( repo1 );
@@ -127,9 +128,9 @@ public class TestBannedRepositories
 
     public void testAllowedRepositoriesException()
     {
-        DefaultArtifactRepository repo1 = new DefaultArtifactRepository( "repo1", "http://repo1/", null );
-        DefaultArtifactRepository repo2 = new DefaultArtifactRepository( "repo1", "http://repo1/test", null );
-        DefaultArtifactRepository repo3 = new DefaultArtifactRepository( "repo1", "http://repo2/test", null );
+        ArtifactRepository repo1 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/", defaultRepositoryLayout, null, null );
+        ArtifactRepository repo2 = MavenRepositorySystem.createArtifactRepository( "repo1", "http://repo1/test", defaultRepositoryLayout, null, null );
+        ArtifactRepository repo3 = MavenRepositorySystem.createArtifactRepository( "repo2", "http://repo2/test", defaultRepositoryLayout, null, null );
         List<ArtifactRepository> repos = new ArrayList<ArtifactRepository>();
         repos.add( repo1 );
         repos.add( repo2 );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
@@ -25,10 +25,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import junit.framework.TestCase;
+
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugins.enforcer.utils.PluginWrapper;
 
 /**
@@ -37,7 +38,7 @@ import org.apache.maven.plugins.enforcer.utils.PluginWrapper;
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
 public class TestRequirePluginVersions
-    extends AbstractMojoTestCase
+    extends TestCase
 {
 
     /**

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
@@ -29,6 +29,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.plugins.enforcer.utils.EnforcerRuleUtilsHelper;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
 
 /**
  * The Class TestNoSnapshots.
@@ -96,10 +97,11 @@ public class TestRequireReleaseDeps
     {
         RequireReleaseDeps rule = new RequireReleaseDeps()
         {
-            protected Set<Artifact> getDependenciesToCheck( MavenProject project )
+            protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
             {
                 // the integration with dependencyGraphTree is verified with the integration tests
-                // for unit-testing 
+                // for unit-testing
+                MavenProject project = buildingRequest.getProject();
                 return isSearchTransitive() ? project.getArtifacts() : project.getDependencyArtifacts();
             }
         };        

--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -125,6 +125,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>index-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>index</goal>
+            </goals>
+            <configuration>
+              <includeArtifactIds>enforcer-rules</includeArtifactIds>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <resources>
       <!-- Include super-pom defined main/resources

--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -179,6 +179,9 @@
               <postBuildHookScript>verify</postBuildHookScript>
               <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
               <settingsFile>src/it/mrm/settings.xml</settingsFile>
+              <environmentVariables>
+                <MAVEN_DEBUG_OPTS>-XX:+IgnoreUnrecognizedVMOptions</MAVEN_DEBUG_OPTS>
+              </environmentVariables>
               <goals>
                 <goal>validate</goal>
               </goals>
@@ -202,7 +205,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>mrm-maven-plugin</artifactId>
-            <version>1.0.0</version>
+            <version>1.2.0</version>
             <executions>
               <execution>
                 <goals>

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -28,20 +28,23 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 /**
  * Exhaustively check the enforcer mojo.
  * 
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
-@RunWith( MockitoJUnitRunner.class )
 public class TestEnforceMojo
 {
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule().strictness( Strictness.LENIENT );
 
     @InjectMocks
     EnforceMojo mojo;

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
     </site>
   </distributionManagement>
   <properties>
-    <javaVersion>7</javaVersion>
-    <maven.version>3.5.4</maven.version>
+    <maven.version>3.3.9</maven.version>
     <maven.site.path>enforcer-archives/enforcer-LATEST</maven.site.path>
+    <sisu-inject.version>0.3.3</sisu-inject.version>
     <javaVersion>7</javaVersion>
   </properties>
 
@@ -163,6 +163,20 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>sisu-maven-plugin</artifactId>
+          <version>${sisu-inject.version}</version>
+          <executions>
+            <execution>
+              <id>index-module</id>
+              <goals>
+                <goal>main-index</goal>
+                <goal>test-index</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
     </site>
   </distributionManagement>
   <properties>
-    <maven.version>3.0</maven.version>
+    <javaVersion>7</javaVersion>
+    <maven.version>3.5.4</maven.version>
     <maven.site.path>enforcer-archives/enforcer-LATEST</maven.site.path>
     <javaVersion>7</javaVersion>
   </properties>
@@ -103,12 +104,6 @@
         <version>${maven.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-compat</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-common-artifact-filters</artifactId>
         <version>3.0.1</version>
@@ -121,7 +116,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -132,7 +127,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.5</version> <!-- commons-lang3 >= 3.6 require at least Java 7 -->
+        <version>3.8.1</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -142,13 +137,13 @@
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>
         <artifactId>maven-plugin-testing-harness</artifactId>
-        <version>2.1</version>
+        <version>3.3.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-dependency-tree</artifactId>
-        <version>2.2</version>
+        <version>3.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -192,7 +187,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-7</version>
+            <version>1.0-beta-9</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Fixes main performance issue in bannedDependencies, and other rules that use DependencyGraphBuilder or the legacy DependencyTreeBuilder.


 - [/] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
