### PR TITLE
[MENFORCER-336] - Fixes race condition in EvaluateBeanshell

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/EvaluateBeanshell.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/EvaluateBeanshell.java
@@ -38,7 +38,14 @@ public class EvaluateBeanshell
 {
 
     /** Beanshell interpreter. */
-    private static final Interpreter BSH = new Interpreter();
+    private static final ThreadLocal<Interpreter> INTERPRETER = new ThreadLocal<Interpreter>()
+    {
+        @Override
+        protected Interpreter initialValue()
+        {
+            return new Interpreter();
+        }
+    };
 
     /** The condition to be evaluated.
      *  
@@ -99,7 +106,7 @@ public class EvaluateBeanshell
         Boolean evaluation = Boolean.FALSE;
         try
         {
-            evaluation = (Boolean) BSH.eval( script );
+            evaluation = (Boolean) INTERPRETER.get().eval( script );
             log.debug( "Echo evaluating : " + evaluation );
         }
         catch ( EvalError ex )


### PR DESCRIPTION
The Beanshell interpreter in EvaluateBeanShell was a static field, but this object is not thread safe. I wrapped the BeanShell interpreter in a ThreadLocal. The alternative would be to create a new Interpreter on each invocation, but I don't know how expensive the Interpreter object is. Using ThreadLocal is probably closer to the original design where it was a singleton. 

I added a (somewhat naive) unit test that failed on every run on my old 4 core mac, and ran green with the new ThreadLocal variant. However I am not sure if this is the correct way to test this, or how this will behave on other hardware. 

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER-336) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

