### PR TITLE
Remove obsolete section

### DIFF
--- a/maven-enforcer-plugin/src/site/apt/index.apt
+++ b/maven-enforcer-plugin/src/site/apt/index.apt
@@ -36,10 +36,6 @@ Maven Enforcer Plugin - The Loving Iron Fist of Maven\x99
 
   *{{{./display-info-mojo.html}enforcer:display-info}} display the current information as detected by the built-in rules.
 
-* Using 3.0.0-M2+
-
-  The minimum needed JDK is now JDK7+.
-  
 * Usage
 
   General instructions on how to use the Enforcer Plugin can be found on the {{{./usage.html}usage page}}.


### PR DESCRIPTION
@khmarbaise Java 8 is now required and plugin is at M3. Let's just remove this section that seems to go out of date and isn't really needed here.
