### PR TITLE
remove unused, deprecated field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target
 .settings
 .classpath
 .project
+.checkstyle
+

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequirePluginVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequirePluginVersions.java
@@ -647,7 +647,7 @@ public class RequirePluginVersions
 
                 if ( isValidVersion( version ) )
                 {
-                    helper.getLog().debug( "checking for notEmpty and notIsWhiespace(): " + version );
+                    helper.getLog().debug( "checking for notEmpty and notIsWhitespace(): " + version );
                     if ( banRelease && version.equals( "RELEASE" ) )
                     {
                         return false;

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
@@ -40,9 +40,6 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 public class EnforcerRuleUtils
 {
 
-    /** The factory. */
-    ArtifactFactory factory;
-
     /** The resolver. */
     ArtifactResolver resolver;
 
@@ -63,7 +60,7 @@ public class EnforcerRuleUtils
     /**
      * Instantiates a new enforcer rule utils.
      *
-     * @param theFactory the the factory
+     * @param theFactory unused
      * @param theResolver the the resolver
      * @param theLocal the the local
      * @param theRemoteRepositories the the remote repositories
@@ -74,7 +71,6 @@ public class EnforcerRuleUtils
                               List<ArtifactRepository> theRemoteRepositories, MavenProject project, Log theLog )
     {
         super();
-        this.factory = theFactory;
         this.resolver = theResolver;
         this.local = theLocal;
         this.remoteRepositories = theRemoteRepositories;
@@ -95,7 +91,6 @@ public class EnforcerRuleUtils
         // helper.
         try
         {
-            factory = (ArtifactFactory) helper.getComponent( ArtifactFactory.class );
             resolver = (ArtifactResolver) helper.getComponent( ArtifactResolver.class );
             local = (ArtifactRepository) helper.evaluate( "${localRepository}" );
             project = (MavenProject) helper.evaluate( "${project}" );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
@@ -51,10 +51,10 @@ public class TestRequirePluginVersions
 
         // setup the plugins. I'm setting up the foo group
         // with a few bogus entries and then a real one.
-        // this is to test that the list is exhaustively
+        // to test that the list is exhaustively
         // searched for versions before giving up.
         // banLatest/Release will fail if it is found
-        // anywhere in the list
+        // anywhere in the list.
         List<Plugin> plugins = new ArrayList<Plugin>();
         plugins.add( EnforcerTestUtils.newPlugin( "group", "a-artifact", "1.0" ) );
         plugins.add( EnforcerTestUtils.newPlugin( "group", "foo", null ) );
@@ -93,7 +93,7 @@ public class TestRequirePluginVersions
         rule.setBanLatest( true );
         assertFalse( rule.hasValidVersionSpecified( helper, source, pluginWrappers ) );
 
-        // check that LATEST is exhausively checked
+        // check that LATEST is exhaustively checked
         rule.setBanSnapshots( false );
         source.setArtifactId( "f-artifact" );
         assertFalse( rule.hasValidVersionSpecified( helper, source, pluginWrappers ) );


### PR DESCRIPTION
@khmarbaise Something I found while trying, and failing, to upgrade this to Maven 3.1. I think artifactFactory in EnforcerRuleUtils is unused, and the tests pass, but perhaps there's some weird class loading implication?