### PR TITLE
[MENFORCER-360] - requireUpperBoundDeps should have option to check for same major version

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDeps.java
@@ -62,6 +62,11 @@ public class RequireUpperBoundDeps
     private boolean uniqueVersions;
 
     /**
+     * @since 3.0.0
+     */
+    private boolean sameMajorVersions;
+
+    /**
      * Dependencies to ignore.
      *
      * @since TBD
@@ -84,6 +89,17 @@ public class RequireUpperBoundDeps
     public void setUniqueVersions( boolean uniqueVersions )
     {
         this.uniqueVersions = uniqueVersions;
+    }
+
+    /**
+     * Set to {@code true} if dependencies should use same major version (semantic versioning).
+     *
+     * @param sameMajorVersions
+     * @since 3.0.0
+     */
+    public void setSameMajorVersions( boolean sameMajorVersions )
+    {
+        this.sameMajorVersions = sameMajorVersions;
     }
 
     /**
@@ -161,6 +177,7 @@ public class RequireUpperBoundDeps
             DependencyNode node = getNode( helper );
             RequireUpperBoundDepsVisitor visitor = new RequireUpperBoundDepsVisitor();
             visitor.setUniqueVersions( uniqueVersions );
+            visitor.setSameMajorVersions( sameMajorVersions );
             visitor.setIncludes( includes );
             node.accept( visitor );
             List<String> errorMessages = buildErrorMessages( visitor.getConflicts() );
@@ -262,11 +279,18 @@ public class RequireUpperBoundDeps
 
         private boolean uniqueVersions;
 
+        private boolean sameMajorVersions;
+
         private List<String> includes = null;
 
         public void setUniqueVersions( boolean uniqueVersions )
         {
             this.uniqueVersions = uniqueVersions;
+        }
+
+        public void setSameMajorVersions( boolean sameMajorVersions )
+        {
+            this.sameMajorVersions = sameMajorVersions;
         }
 
         public void setIncludes( List<String> includes )
@@ -340,6 +364,10 @@ public class RequireUpperBoundDeps
             {
                 ArtifactVersion version = pair.extractArtifactVersion( uniqueVersions, true );
                 if ( resolvedVersion.compareTo( version ) < 0 )
+                {
+                    return true;
+                }
+                else if ( sameMajorVersions && resolvedVersion.getMajorVersion() != version.getMajorVersion() )
                 {
                     return true;
                 }

--- a/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
+++ b/enforcer-rules/src/site/apt/requireUpperBoundDeps.apt.vm
@@ -104,6 +104,8 @@ and
                 <requireUpperBoundDeps>
                   <!-- 'uniqueVersions' (default:false) can be set to true if you want to compare the timestamped SNAPSHOTs  -->
                   <!-- <uniqueVersions>true</uniqueVersions> -->
+                  <!-- 'sameMajorVersions' (default:false) can be set to true if you want that dependencies all use the same major version (semantic versioning)  -->
+                  <!-- <sameMajorVersions>true</sameMajorVersions> -->
                   <!-- If you wish to ignore certain cases:
                   <excludes>
                     <exclude>com.google.guava:guava</exclude>


### PR DESCRIPTION
An option is added to the built-in requireUpperBoundDeps rule to check for same major version (following semver.org).

So a (transitive) dependency on groupId:artifactId:1.0.0 and on groupId:artifactId:2.0.0 means that we have a conflict.


To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


