### PR TITLE
Support for Java 13, 14 and 15 using Extra Enforcer Rules 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Upgrading to Extra Enforcer Rules 1.3, so Maven Enforcer Plugin could support Java 13, 14 and 15.