### PR TITLE
[MENFORCER-372] JUnit 5

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -91,11 +91,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -86,8 +86,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -91,8 +91,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BanDistributionManagementTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BanDistributionManagementTest.java
@@ -70,11 +70,11 @@ public class BanDistributionManagementTest
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepository()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             BanDistributionManagement rule =
-                    setupProjectWithDistributionManagement(new DeploymentRepository(), null, null);
-            rule.execute(helper);
-        });
+                setupProjectWithDistributionManagement( new DeploymentRepository(), null, null );
+            rule.execute( helper );
+        } );
         // intentionally no assert cause we expect an exception.
     }
 
@@ -96,11 +96,11 @@ public class BanDistributionManagementTest
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepositorySnapshotRepository()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             BanDistributionManagement rule =
-                    setupProjectWithDistributionManagement(new DeploymentRepository(), new DeploymentRepository(), null);
-            rule.execute(helper);
-        });
+                setupProjectWithDistributionManagement( new DeploymentRepository(), new DeploymentRepository(), null );
+            rule.execute( helper );
+        } );
         // intentionally no assert cause we expect an exception.
     }
 
@@ -125,13 +125,13 @@ public class BanDistributionManagementTest
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepositorySnapshotRepositorySite()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             BanDistributionManagement rule =
-                    setupProjectWithDistributionManagement(new DeploymentRepository(), new DeploymentRepository(),
-                            new Site());
-            rule.execute(helper);
+                setupProjectWithDistributionManagement( new DeploymentRepository(), new DeploymentRepository(),
+                                                        new Site() );
+            rule.execute( helper );
             // intentionally no assert cause we expect an exception.
-        });
+        } );
         // intentionally no assert cause we expect an exception.
     }
 
@@ -229,7 +229,7 @@ public class BanDistributionManagementTest
     private BanDistributionManagement setupProjectWithParentDistributionManagement( DeploymentRepository repository,
                                                                                     DeploymentRepository snapshotRepository,
                                                                                     Site site )
-                                                                                        throws ExpressionEvaluationException
+        throws ExpressionEvaluationException
     {
         project = setupProject( null );
 
@@ -262,7 +262,7 @@ public class BanDistributionManagementTest
     private BanDistributionManagement setupProjectWithDistributionManagement( DeploymentRepository repository,
                                                                               DeploymentRepository snapshotRepository,
                                                                               Site site )
-                                                                                  throws ExpressionEvaluationException
+        throws ExpressionEvaluationException
     {
         DistributionManagement dm = mock( DistributionManagement.class );
         when( dm.getRepository() ).thenReturn( repository );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BanDistributionManagementTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BanDistributionManagementTest.java
@@ -31,7 +31,9 @@ import org.apache.maven.model.Site;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class is intended to test the {@link BanDistributionManagement} rule.
@@ -64,13 +66,15 @@ public class BanDistributionManagementTest
      * 
      * @throws Exception if any occurs
      */
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepository()
         throws Exception
     {
-        BanDistributionManagement rule =
-            setupProjectWithDistributionManagement( new DeploymentRepository(), null, null );
-        rule.execute( helper );
+        assertThrows(EnforcerRuleException.class, () -> {
+            BanDistributionManagement rule =
+                    setupProjectWithDistributionManagement(new DeploymentRepository(), null, null);
+            rule.execute(helper);
+        });
         // intentionally no assert cause we expect an exception.
     }
 
@@ -88,13 +92,15 @@ public class BanDistributionManagementTest
      * 
      * @throws Exception if any occurs
      */
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepositorySnapshotRepository()
         throws Exception
     {
-        BanDistributionManagement rule =
-            setupProjectWithDistributionManagement( new DeploymentRepository(), new DeploymentRepository(), null );
-        rule.execute( helper );
+        assertThrows(EnforcerRuleException.class, () -> {
+            BanDistributionManagement rule =
+                    setupProjectWithDistributionManagement(new DeploymentRepository(), new DeploymentRepository(), null);
+            rule.execute(helper);
+        });
         // intentionally no assert cause we expect an exception.
     }
 
@@ -115,14 +121,17 @@ public class BanDistributionManagementTest
      * 
      * @throws Exception if any occurs
      */
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldThrowExceptionIfDistributionManagementIsDefinedWithRepositorySnapshotRepositorySite()
         throws Exception
     {
-        BanDistributionManagement rule =
-            setupProjectWithDistributionManagement( new DeploymentRepository(), new DeploymentRepository(),
-                                                    new Site() );
-        rule.execute( helper );
+        assertThrows(EnforcerRuleException.class, () -> {
+            BanDistributionManagement rule =
+                    setupProjectWithDistributionManagement(new DeploymentRepository(), new DeploymentRepository(),
+                            new Site());
+            rule.execute(helper);
+            // intentionally no assert cause we expect an exception.
+        });
         // intentionally no assert cause we expect an exception.
     }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/BannedDependenciesTestSetup.java
@@ -55,6 +55,7 @@ public class BannedDependenciesTestSetup
     }
 
     private List<String> excludes;
+
     private List<String> includes;
 
     private BannedDependencies rule;
@@ -73,12 +74,14 @@ public class BannedDependenciesTestSetup
         rule.execute( helper );
     }
 
-    public void addIncludeExcludeAndRunRule (String incAdd, String excAdd) throws EnforcerRuleException {
+    public void addIncludeExcludeAndRunRule( String incAdd, String excAdd )
+        throws EnforcerRuleException
+    {
         excludes.add( excAdd );
         includes.add( incAdd );
         rule.execute( helper );
     }
-    
+
     public List<String> getExcludes()
     {
         return excludes;
@@ -106,6 +109,4 @@ public class BannedDependenciesTestSetup
         return rule;
     }
 
-
 }
-

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/EnforcerTestUtils.java
@@ -69,7 +69,7 @@ public final class EnforcerTestUtils
 
         MavenExecutionRequest mer = mock( MavenExecutionRequest.class );
         ProjectBuildingRequest buildingRequest = mock( ProjectBuildingRequest.class );
-        when( buildingRequest.setRepositorySession( any() )).thenReturn( buildingRequest );
+        when( buildingRequest.setRepositorySession( any() ) ).thenReturn( buildingRequest );
         when( mer.getProjectBuildingRequest() ).thenReturn( buildingRequest );
 
         Properties systemProperties = new Properties();
@@ -135,19 +135,20 @@ public final class EnforcerTestUtils
             eval = new PluginParameterExpressionEvaluator( session, mockExecution );
         }
         PlexusContainer container = Mockito.mock( PlexusContainer.class );
-        
-        Artifact artifact = new DefaultArtifact( "groupId", "artifactId", "version", "compile", "jar",
-                                                 "classifier", null );
+
+        Artifact artifact =
+            new DefaultArtifact( "groupId", "artifactId", "version", "compile", "jar", "classifier", null );
         Artifact v1 = new DefaultArtifact( "groupId", "artifact", "1.0.0", "compile", "jar", "", null );
         Artifact v2 = new DefaultArtifact( "groupId", "artifact", "2.0.0", "compile", "jar", "", null );
         final DefaultDependencyNode node = new DefaultDependencyNode( artifact );
         DefaultDependencyNode child1 = new DefaultDependencyNode( node, v1, null, null, null );
         child1.setChildren( Collections.emptyList() );
-        DefaultDependencyNode child2 = new DefaultDependencyNode( node, v2, null, null, null  );
+        DefaultDependencyNode child2 = new DefaultDependencyNode( node, v2, null, null, null );
         child2.setChildren( Collections.emptyList() );
         node.setChildren( Arrays.asList( child1, child2 ) );
-        
-        DependencyCollectorBuilder dependencyCollectorBuilder = new DependencyCollectorBuilder() {
+
+        DependencyCollectorBuilder dependencyCollectorBuilder = new DependencyCollectorBuilder()
+        {
             @Override
             public org.apache.maven.shared.dependency.graph.DependencyNode collectDependencyGraph( ProjectBuildingRequest buildingRequest,
                                                                                                    ArtifactFilter filter )
@@ -159,7 +160,7 @@ public final class EnforcerTestUtils
 
         try
         {
-            Mockito.when( container.lookup( DependencyCollectorBuilder.class ) ).thenReturn( dependencyCollectorBuilder  );
+            Mockito.when( container.lookup( DependencyCollectorBuilder.class ) ).thenReturn( dependencyCollectorBuilder );
         }
         catch ( ComponentLookupException e )
         {
@@ -193,7 +194,7 @@ public final class EnforcerTestUtils
     {
         InputSource inputSource = new InputSource();
         inputSource.setModelId( "unit" );
-        
+
         Plugin plugin = new Plugin();
         plugin.setArtifactId( artifactId );
         plugin.setGroupId( groupId );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockProject.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/MockProject.java
@@ -100,7 +100,7 @@ public class MockProject
 
     /** The plugin artifact repositories. */
     private List pluginArtifactRepositories;
-    
+
     /** The artifact repositories. */
     private List artifactRepositories;
 
@@ -235,7 +235,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getModulePathAdjustment(org.apache.maven.project.MavenProject)
      */
     public String getModulePathAdjustment( MavenProject mavenProject )
@@ -246,7 +245,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getArtifact()
      */
     public Artifact getArtifact()
@@ -256,7 +254,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setArtifact(org.apache.maven.artifact.Artifact)
      */
     public void setArtifact( Artifact artifact )
@@ -266,7 +263,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getModel()
      */
     public Model getModel()
@@ -276,7 +272,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getParent()
      */
     public MavenProject getParent()
@@ -286,7 +281,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setParent(org.apache.maven.project.MavenProject)
      */
     public void setParent( MavenProject mavenProject )
@@ -296,7 +290,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setRemoteArtifactRepositories(java.util.List)
      */
     public void setRemoteArtifactRepositories( List list )
@@ -306,7 +299,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getRemoteArtifactRepositories()
      */
     public List getRemoteArtifactRepositories()
@@ -316,7 +308,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#hasParent()
      */
     public boolean hasParent()
@@ -333,7 +324,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getFile()
      */
     public File getFile()
@@ -343,7 +333,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setFile(java.io.File)
      */
     public void setFile( File file )
@@ -353,7 +342,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getBasedir()
      */
     public File getBasedir()
@@ -377,7 +365,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setDependencies(java.util.List)
      */
     public void setDependencies( List list )
@@ -387,7 +374,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDependencies()
      */
     public List getDependencies()
@@ -411,7 +397,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDependencyManagement()
      */
     public DependencyManagement getDependencyManagement()
@@ -426,7 +411,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addCompileSourceRoot(java.lang.String)
      */
     public void addCompileSourceRoot( String string )
@@ -443,7 +427,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addScriptSourceRoot(java.lang.String)
      */
     public void addScriptSourceRoot( String string )
@@ -460,7 +443,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addTestCompileSourceRoot(java.lang.String)
      */
     public void addTestCompileSourceRoot( String string )
@@ -477,7 +459,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCompileSourceRoots()
      */
     public List getCompileSourceRoots()
@@ -487,7 +468,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getScriptSourceRoots()
      */
     public List getScriptSourceRoots()
@@ -497,7 +477,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getTestCompileSourceRoots()
      */
     public List getTestCompileSourceRoots()
@@ -507,7 +486,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCompileClasspathElements()
      */
     public List getCompileClasspathElements()
@@ -528,7 +506,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCompileArtifacts()
      */
     public List getCompileArtifacts()
@@ -538,7 +515,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCompileDependencies()
      */
     public List getCompileDependencies()
@@ -548,7 +524,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getTestClasspathElements()
      */
     public List getTestClasspathElements()
@@ -559,7 +534,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getTestArtifacts()
      */
     public List getTestArtifacts()
@@ -569,7 +543,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getTestDependencies()
      */
     public List getTestDependencies()
@@ -579,7 +552,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getRuntimeClasspathElements()
      */
     public List getRuntimeClasspathElements()
@@ -590,7 +562,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getRuntimeArtifacts()
      */
     public List getRuntimeArtifacts()
@@ -600,7 +571,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getRuntimeDependencies()
      */
     public List getRuntimeDependencies()
@@ -610,7 +580,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getSystemClasspathElements()
      */
     public List getSystemClasspathElements()
@@ -621,7 +590,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getSystemArtifacts()
      */
     public List getSystemArtifacts()
@@ -841,7 +809,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getSystemDependencies()
      */
     public List getSystemDependencies()
@@ -851,7 +818,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setModelVersion(java.lang.String)
      */
     public void setModelVersion( String string )
@@ -861,7 +827,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getModelVersion()
      */
     public String getModelVersion()
@@ -871,7 +836,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getId()
      */
     public String getId()
@@ -881,7 +845,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setGroupId(java.lang.String)
      */
     public void setGroupId( String string )
@@ -891,7 +854,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getGroupId()
      */
     public String getGroupId()
@@ -901,7 +863,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setArtifactId(java.lang.String)
      */
     public void setArtifactId( String string )
@@ -911,7 +872,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getArtifactId()
      */
     public String getArtifactId()
@@ -921,7 +881,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setName(java.lang.String)
      */
     public void setName( String string )
@@ -931,7 +890,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getName()
      */
     public String getName()
@@ -941,7 +899,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setVersion(java.lang.String)
      */
     public void setVersion( String string )
@@ -951,7 +908,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getVersion()
      */
     public String getVersion()
@@ -961,7 +917,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPackaging()
      */
     public String getPackaging()
@@ -971,7 +926,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setPackaging(java.lang.String)
      */
     public void setPackaging( String string )
@@ -981,7 +935,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setInceptionYear(java.lang.String)
      */
     public void setInceptionYear( String string )
@@ -991,7 +944,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getInceptionYear()
      */
     public String getInceptionYear()
@@ -1001,7 +953,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setUrl(java.lang.String)
      */
     public void setUrl( String string )
@@ -1011,7 +962,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getUrl()
      */
     public String getUrl()
@@ -1021,7 +971,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPrerequisites()
      */
     public Prerequisites getPrerequisites()
@@ -1031,7 +980,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setIssueManagement(org.apache.maven.model.IssueManagement)
      */
     public void setIssueManagement( IssueManagement issueManagement )
@@ -1041,7 +989,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCiManagement()
      */
     public CiManagement getCiManagement()
@@ -1051,7 +998,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setCiManagement(org.apache.maven.model.CiManagement)
      */
     public void setCiManagement( CiManagement ciManagement )
@@ -1061,7 +1007,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getIssueManagement()
      */
     public IssueManagement getIssueManagement()
@@ -1071,8 +1016,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
-     * @see org.apache.maven.project.MavenProject#setDistributionManagement(org.apache.maven.model.DistributionManagement)
+     * @see
+     * org.apache.maven.project.MavenProject#setDistributionManagement(org.apache.maven.model.DistributionManagement)
      */
     public void setDistributionManagement( DistributionManagement distributionManagement )
     {
@@ -1081,7 +1026,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDistributionManagement()
      */
     public DistributionManagement getDistributionManagement()
@@ -1091,7 +1035,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setDescription(java.lang.String)
      */
     public void setDescription( String string )
@@ -1101,7 +1044,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDescription()
      */
     public String getDescription()
@@ -1111,7 +1053,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setOrganization(org.apache.maven.model.Organization)
      */
     public void setOrganization( Organization organization )
@@ -1121,7 +1062,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getOrganization()
      */
     public Organization getOrganization()
@@ -1131,7 +1071,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setScm(org.apache.maven.model.Scm)
      */
     public void setScm( Scm scm )
@@ -1141,7 +1080,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getScm()
      */
     public Scm getScm()
@@ -1151,7 +1089,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setMailingLists(java.util.List)
      */
     public void setMailingLists( List list )
@@ -1161,7 +1098,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getMailingLists()
      */
     public List getMailingLists()
@@ -1171,7 +1107,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addMailingList(org.apache.maven.model.MailingList)
      */
     public void addMailingList( MailingList mailingList )
@@ -1181,7 +1116,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setDevelopers(java.util.List)
      */
     public void setDevelopers( List list )
@@ -1191,7 +1125,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDevelopers()
      */
     public List getDevelopers()
@@ -1201,7 +1134,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addDeveloper(org.apache.maven.model.Developer)
      */
     public void addDeveloper( Developer developer )
@@ -1211,7 +1143,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setContributors(java.util.List)
      */
     public void setContributors( List list )
@@ -1221,7 +1152,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getContributors()
      */
     public List getContributors()
@@ -1231,7 +1161,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addContributor(org.apache.maven.model.Contributor)
      */
     public void addContributor( Contributor contributor )
@@ -1241,7 +1170,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setBuild(org.apache.maven.model.Build)
      */
     public void setBuild( Build build )
@@ -1251,7 +1179,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getBuild()
      */
     public Build getBuild()
@@ -1261,7 +1188,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getResources()
      */
     public List getResources()
@@ -1271,7 +1197,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getTestResources()
      */
     public List getTestResources()
@@ -1281,7 +1206,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addResource(org.apache.maven.model.Resource)
      */
     public void addResource( Resource resource )
@@ -1291,7 +1215,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addTestResource(org.apache.maven.model.Resource)
      */
     public void addTestResource( Resource resource )
@@ -1301,7 +1224,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setReporting(org.apache.maven.model.Reporting)
      */
     public void setReporting( Reporting reporting )
@@ -1311,7 +1233,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getReporting()
      */
     public Reporting getReporting()
@@ -1321,7 +1242,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setLicenses(java.util.List)
      */
     public void setLicenses( List list )
@@ -1331,7 +1251,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getLicenses()
      */
     public List getLicenses()
@@ -1341,7 +1260,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addLicense(org.apache.maven.model.License)
      */
     public void addLicense( License license )
@@ -1351,7 +1269,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setArtifacts(java.util.Set)
      */
     public void setArtifacts( Set set )
@@ -1361,7 +1278,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getArtifacts()
      */
     public Set getArtifacts()
@@ -1378,7 +1294,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getArtifactMap()
      */
     public Map getArtifactMap()
@@ -1388,7 +1303,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setPluginArtifacts(java.util.Set)
      */
     public void setPluginArtifacts( Set set )
@@ -1398,7 +1312,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPluginArtifacts()
      */
     public Set getPluginArtifacts()
@@ -1408,7 +1321,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPluginArtifactMap()
      */
     public Map getPluginArtifactMap()
@@ -1418,7 +1330,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setReportArtifacts(java.util.Set)
      */
     public void setReportArtifacts( Set set )
@@ -1428,7 +1339,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getReportArtifacts()
      */
     public Set getReportArtifacts()
@@ -1438,7 +1348,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getReportArtifactMap()
      */
     public Map getReportArtifactMap()
@@ -1448,7 +1357,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setExtensionArtifacts(java.util.Set)
      */
     public void setExtensionArtifacts( Set set )
@@ -1458,7 +1366,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getExtensionArtifacts()
      */
     public Set getExtensionArtifacts()
@@ -1468,7 +1375,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getExtensionArtifactMap()
      */
     public Map getExtensionArtifactMap()
@@ -1478,7 +1384,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setParentArtifact(org.apache.maven.artifact.Artifact)
      */
     public void setParentArtifact( Artifact artifact )
@@ -1488,12 +1393,11 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getParentArtifact()
      */
     public Artifact getParentArtifact()
     {
-        if (parent !=null)
+        if ( parent != null )
         {
             return parent.getArtifact();
         }
@@ -1504,7 +1408,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getRepositories()
      */
     public List getRepositories()
@@ -1514,7 +1417,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getReportPlugins()
      */
     public List getReportPlugins()
@@ -1524,7 +1426,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getBuildPlugins()
      */
     public List getBuildPlugins()
@@ -1534,7 +1435,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getModules()
      */
     public List getModules()
@@ -1544,7 +1444,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPluginManagement()
      */
     public PluginManagement getPluginManagement()
@@ -1554,7 +1453,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addPlugin(org.apache.maven.model.Plugin)
      */
     public void addPlugin( Plugin plugin )
@@ -1564,7 +1462,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#injectPluginManagementInfo(org.apache.maven.model.Plugin)
      */
     public void injectPluginManagementInfo( Plugin plugin )
@@ -1574,7 +1471,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getCollectedProjects()
      */
     public List getCollectedProjects()
@@ -1584,7 +1480,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setCollectedProjects(java.util.List)
      */
     public void setCollectedProjects( List list )
@@ -1594,7 +1489,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setPluginArtifactRepositories(java.util.List)
      */
     public void setPluginArtifactRepositories( List list )
@@ -1604,7 +1498,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPluginArtifactRepositories()
      */
     public List getPluginArtifactRepositories()
@@ -1614,7 +1507,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDistributionManagementArtifactRepository()
      */
     public ArtifactRepository getDistributionManagementArtifactRepository()
@@ -1624,7 +1516,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getPluginRepositories()
      */
     public List getPluginRepositories()
@@ -1634,7 +1525,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setActiveProfiles(java.util.List)
      */
     public void setActiveProfiles( List list )
@@ -1644,7 +1534,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getActiveProfiles()
      */
     public List getActiveProfiles()
@@ -1654,7 +1543,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addAttachedArtifact(org.apache.maven.artifact.Artifact)
      */
     public void addAttachedArtifact( Artifact theArtifact )
@@ -1671,7 +1559,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getAttachedArtifacts()
      */
     public List getAttachedArtifacts()
@@ -1681,9 +1568,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getGoalConfiguration(java.lang.String, java.lang.String,
-     *      java.lang.String, java.lang.String)
+     * java.lang.String, java.lang.String)
      */
     public Xpp3Dom getGoalConfiguration( String string, String string1, String string2, String string3 )
     {
@@ -1692,9 +1578,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getReportConfiguration(java.lang.String, java.lang.String,
-     *      java.lang.String)
+     * java.lang.String)
      */
     public Xpp3Dom getReportConfiguration( String string, String string1, String string2 )
     {
@@ -1703,7 +1588,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getExecutionProject()
      */
     public MavenProject getExecutionProject()
@@ -1713,7 +1597,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setExecutionProject(org.apache.maven.project.MavenProject)
      */
     public void setExecutionProject( MavenProject mavenProject )
@@ -1723,7 +1606,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#writeModel(java.io.Writer)
      */
     public void writeModel( Writer writer )
@@ -1734,7 +1616,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#writeOriginalModel(java.io.Writer)
      */
     public void writeOriginalModel( Writer writer )
@@ -1745,7 +1626,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDependencyArtifacts()
      */
     public Set getDependencyArtifacts()
@@ -1755,7 +1635,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setDependencyArtifacts(java.util.Set)
      */
     public void setDependencyArtifacts( Set set )
@@ -1765,8 +1644,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
-     * @see org.apache.maven.project.MavenProject#setReleaseArtifactRepository(org.apache.maven.artifact.repository.ArtifactRepository)
+     * @see org.apache.maven.project.MavenProject#setReleaseArtifactRepository(org.apache.maven.artifact.repository.
+     * ArtifactRepository)
      */
     public void setReleaseArtifactRepository( ArtifactRepository artifactRepository )
     {
@@ -1775,8 +1654,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
-     * @see org.apache.maven.project.MavenProject#setSnapshotArtifactRepository(org.apache.maven.artifact.repository.ArtifactRepository)
+     * @see org.apache.maven.project.MavenProject#setSnapshotArtifactRepository(org.apache.maven.artifact.repository.
+     * ArtifactRepository)
      */
     public void setSnapshotArtifactRepository( ArtifactRepository artifactRepository )
     {
@@ -1785,7 +1664,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setOriginalModel(org.apache.maven.model.Model)
      */
     public void setOriginalModel( Model model )
@@ -1795,7 +1673,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getOriginalModel()
      */
     public Model getOriginalModel()
@@ -1805,7 +1682,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getBuildExtensions()
      */
     public List getBuildExtensions()
@@ -1815,9 +1691,8 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#createArtifacts(org.apache.maven.artifact.factory.ArtifactFactory,
-     *      java.lang.String, org.apache.maven.artifact.resolver.filter.ArtifactFilter)
+     * java.lang.String, org.apache.maven.artifact.resolver.filter.ArtifactFilter)
      */
     public Set createArtifacts( ArtifactFactory artifactFactory, String string, ArtifactFilter artifactFilter )
         throws InvalidDependencyVersionException
@@ -1827,7 +1702,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#addProjectReference(org.apache.maven.project.MavenProject)
      */
     public void addProjectReference( MavenProject mavenProject )
@@ -1837,7 +1711,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#attachArtifact(java.lang.String, java.lang.String, java.io.File)
      */
     public void attachArtifact( String string, String string1, File theFile )
@@ -1847,7 +1720,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getProperties()
      */
     public Properties getProperties()
@@ -1868,7 +1740,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getFilters()
      */
     public List getFilters()
@@ -1878,7 +1749,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getProjectReferences()
      */
     public Map getProjectReferences()
@@ -1888,7 +1758,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#isExecutionRoot()
      */
     public boolean isExecutionRoot()
@@ -1898,7 +1767,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#setExecutionRoot(boolean)
      */
     public void setExecutionRoot( boolean b )
@@ -1908,7 +1776,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#getDefaultGoal()
      */
     public String getDefaultGoal()
@@ -1918,7 +1785,6 @@ public class MockProject
 
     /*
      * (non-Javadoc)
-     *
      * @see org.apache.maven.project.MavenProject#replaceWithActiveArtifact(org.apache.maven.artifact.Artifact)
      */
     public Artifact replaceWithActiveArtifact( Artifact theArtifact )

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/ReactorModuleConvergenceTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/ReactorModuleConvergenceTest.java
@@ -98,18 +98,18 @@ public class ReactorModuleConvergenceTest
     public void shouldFailWithWrongVersionInOneChild()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
-            MavenProject mp2 = createProjectChild1(mp1);
-            MavenProject mp3 = createProjectChild2WithWrongVersion(mp1);
+            MavenProject mp2 = createProjectChild1( mp1 );
+            MavenProject mp3 = createProjectChild2WithWrongVersion( mp1 );
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
+            setupSortedProjects( theList );
 
-            rule.execute(helper);
+            rule.execute( helper );
 
             // intentionally no assertTrue() cause we expect getting an exception.
-        });
+        } );
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
@@ -118,26 +118,26 @@ public class ReactorModuleConvergenceTest
     public void shouldFailWithWrongParent()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
 
-            MavenProject wrongParentVerison = mock(MavenProject.class);
-            when(wrongParentVerison.getGroupId()).thenReturn("org.apache.enforcer");
-            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
-            when(wrongParentVerison.getVersion()).thenReturn("1.1-SNAPSHOT");
-            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.1-SNAPSHOT");
-            when(wrongParentVerison.getDependencies()).thenReturn(Collections.<Dependency>emptyList());
+            MavenProject wrongParentVerison = mock( MavenProject.class );
+            when( wrongParentVerison.getGroupId() ).thenReturn( "org.apache.enforcer" );
+            when( wrongParentVerison.getArtifactId() ).thenReturn( "m1" );
+            when( wrongParentVerison.getVersion() ).thenReturn( "1.1-SNAPSHOT" );
+            when( wrongParentVerison.getId() ).thenReturn( "org.apache.enforcer:m1:jar:1.1-SNAPSHOT" );
+            when( wrongParentVerison.getDependencies() ).thenReturn( Collections.<Dependency>emptyList() );
 
-            MavenProject mp2 = createProjectChild2(wrongParentVerison);
-            MavenProject mp3 = createProjectChild2(mp1);
+            MavenProject mp2 = createProjectChild2( wrongParentVerison );
+            MavenProject mp3 = createProjectChild2( mp1 );
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
+            setupSortedProjects( theList );
 
-            rule.execute(helper);
+            rule.execute( helper );
 
             // intentionally no assertTrue() cause we expect getting an exception.
-        });
+        } );
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
@@ -162,42 +162,42 @@ public class ReactorModuleConvergenceTest
     public void shouldFailWithMissingParentsInReactory()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
-            MavenProject mp2 = createProjectChild1(mp1);
-            MavenProject mp3 = createProjectChild2(null);
+            MavenProject mp2 = createProjectChild1( mp1 );
+            MavenProject mp3 = createProjectChild2( null );
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
+            setupSortedProjects( theList );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     @Test
     public void shouldFailWithAParentWhichIsNotPartOfTheReactory()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
 
-            MavenProject wrongParentVerison = mock(MavenProject.class);
-            when(wrongParentVerison.getGroupId()).thenReturn("org.apache");
-            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
-            when(wrongParentVerison.getVersion()).thenReturn("1.0-SNAPSHOT");
-            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.0-SNAPSHOT");
-            when(wrongParentVerison.getDependencies()).thenReturn(Collections.<Dependency>emptyList());
+            MavenProject wrongParentVerison = mock( MavenProject.class );
+            when( wrongParentVerison.getGroupId() ).thenReturn( "org.apache" );
+            when( wrongParentVerison.getArtifactId() ).thenReturn( "m1" );
+            when( wrongParentVerison.getVersion() ).thenReturn( "1.0-SNAPSHOT" );
+            when( wrongParentVerison.getId() ).thenReturn( "org.apache.enforcer:m1:jar:1.0-SNAPSHOT" );
+            when( wrongParentVerison.getDependencies() ).thenReturn( Collections.<Dependency>emptyList() );
 
-            MavenProject mp2 = createProjectChild2(wrongParentVerison);
-            MavenProject mp3 = createProjectChild2(mp1);
+            MavenProject mp2 = createProjectChild2( wrongParentVerison );
+            MavenProject mp3 = createProjectChild2( mp1 );
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
+            setupSortedProjects( theList );
 
-            rule.execute(helper);
+            rule.execute( helper );
 
             // intentionally no assertTrue() cause we expect getting an exception.
-        });
+        } );
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
@@ -228,25 +228,25 @@ public class ReactorModuleConvergenceTest
     public void shouldFailWithWrongDependencyInReactor()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
-            MavenProject mp2 = createProjectChild1(mp1);
+            MavenProject mp2 = createProjectChild1( mp1 );
 
-            Dependency goodDependency = createDependency("org.junit", "junit", "2.0");
+            Dependency goodDependency = createDependency( "org.junit", "junit", "2.0" );
 
-            Dependency wrongDepFromReactor = createDependency("org.apache.enforcer", "m2", "1.1-SNAPSHOT");
-            List<Dependency> depList = Arrays.asList(goodDependency, wrongDepFromReactor);
-            when(mp2.getDependencies()).thenReturn(depList);
+            Dependency wrongDepFromReactor = createDependency( "org.apache.enforcer", "m2", "1.1-SNAPSHOT" );
+            List<Dependency> depList = Arrays.asList( goodDependency, wrongDepFromReactor );
+            when( mp2.getDependencies() ).thenReturn( depList );
 
-            MavenProject mp3 = createProjectChild2(mp1);
+            MavenProject mp3 = createProjectChild2( mp1 );
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
+            setupSortedProjects( theList );
 
-            rule.execute(helper);
+            rule.execute( helper );
 
             // intentionally no assertTrue() cause we expect getting an exception.
-        });
+        } );
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/ReactorModuleConvergenceTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/ReactorModuleConvergenceTest.java
@@ -27,8 +27,8 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Check reactorModuleConvergence rule.
@@ -50,7 +52,7 @@ public class ReactorModuleConvergenceTest
 
     private ReactorModuleConvergence rule;
 
-    @Before
+    @BeforeEach
     public void before()
         throws ExpressionEvaluationException
     {
@@ -92,42 +94,50 @@ public class ReactorModuleConvergenceTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldFailWithWrongVersionInOneChild()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        MavenProject mp1 = createProjectParent();
-        MavenProject mp2 = createProjectChild1( mp1 );
-        MavenProject mp3 = createProjectChild2WithWrongVersion( mp1 );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject mp1 = createProjectParent();
+            MavenProject mp2 = createProjectChild1(mp1);
+            MavenProject mp3 = createProjectChild2WithWrongVersion(mp1);
 
-        List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
-        setupSortedProjects( theList );
+            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(theList);
 
-        rule.execute( helper );
+            rule.execute(helper);
+
+            // intentionally no assertTrue() cause we expect getting an exception.
+        });
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldFailWithWrongParent()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        MavenProject mp1 = createProjectParent();
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject mp1 = createProjectParent();
 
-        MavenProject wrongParentVerison = mock( MavenProject.class );
-        when( wrongParentVerison.getGroupId() ).thenReturn( "org.apache.enforcer" );
-        when( wrongParentVerison.getArtifactId() ).thenReturn( "m1" );
-        when( wrongParentVerison.getVersion() ).thenReturn( "1.1-SNAPSHOT" );
-        when( wrongParentVerison.getId() ).thenReturn( "org.apache.enforcer:m1:jar:1.1-SNAPSHOT" );
-        when( wrongParentVerison.getDependencies() ).thenReturn( Collections.<Dependency>emptyList() );
+            MavenProject wrongParentVerison = mock(MavenProject.class);
+            when(wrongParentVerison.getGroupId()).thenReturn("org.apache.enforcer");
+            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
+            when(wrongParentVerison.getVersion()).thenReturn("1.1-SNAPSHOT");
+            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.1-SNAPSHOT");
+            when(wrongParentVerison.getDependencies()).thenReturn(Collections.<Dependency>emptyList());
 
-        MavenProject mp2 = createProjectChild2( wrongParentVerison );
-        MavenProject mp3 = createProjectChild2( mp1 );
+            MavenProject mp2 = createProjectChild2(wrongParentVerison);
+            MavenProject mp3 = createProjectChild2(mp1);
 
-        List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
-        setupSortedProjects( theList );
+            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(theList);
 
-        rule.execute( helper );
+            rule.execute(helper);
+
+            // intentionally no assertTrue() cause we expect getting an exception.
+        });
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
@@ -148,40 +158,46 @@ public class ReactorModuleConvergenceTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldFailWithMissingParentsInReactory()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        MavenProject mp1 = createProjectParent();
-        MavenProject mp2 = createProjectChild1( mp1 );
-        MavenProject mp3 = createProjectChild2( null );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject mp1 = createProjectParent();
+            MavenProject mp2 = createProjectChild1(mp1);
+            MavenProject mp3 = createProjectChild2(null);
 
-        List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
-        setupSortedProjects( theList );
+            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(theList);
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldFailWithAParentWhichIsNotPartOfTheReactory()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        MavenProject mp1 = createProjectParent();
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject mp1 = createProjectParent();
 
-        MavenProject wrongParentVerison = mock( MavenProject.class );
-        when( wrongParentVerison.getGroupId() ).thenReturn( "org.apache" );
-        when( wrongParentVerison.getArtifactId() ).thenReturn( "m1" );
-        when( wrongParentVerison.getVersion() ).thenReturn( "1.0-SNAPSHOT" );
-        when( wrongParentVerison.getId() ).thenReturn( "org.apache.enforcer:m1:jar:1.0-SNAPSHOT" );
-        when( wrongParentVerison.getDependencies() ).thenReturn( Collections.<Dependency>emptyList() );
+            MavenProject wrongParentVerison = mock(MavenProject.class);
+            when(wrongParentVerison.getGroupId()).thenReturn("org.apache");
+            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
+            when(wrongParentVerison.getVersion()).thenReturn("1.0-SNAPSHOT");
+            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.0-SNAPSHOT");
+            when(wrongParentVerison.getDependencies()).thenReturn(Collections.<Dependency>emptyList());
 
-        MavenProject mp2 = createProjectChild2( wrongParentVerison );
-        MavenProject mp3 = createProjectChild2( mp1 );
+            MavenProject mp2 = createProjectChild2(wrongParentVerison);
+            MavenProject mp3 = createProjectChild2(mp1);
 
-        List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
-        setupSortedProjects( theList );
+            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(theList);
 
-        rule.execute( helper );
+            rule.execute(helper);
+
+            // intentionally no assertTrue() cause we expect getting an exception.
+        });
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }
@@ -208,25 +224,29 @@ public class ReactorModuleConvergenceTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void shouldFailWithWrongDependencyInReactor()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        MavenProject mp1 = createProjectParent();
-        MavenProject mp2 = createProjectChild1( mp1 );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject mp1 = createProjectParent();
+            MavenProject mp2 = createProjectChild1(mp1);
 
-        Dependency goodDependency = createDependency( "org.junit", "junit", "2.0" );
+            Dependency goodDependency = createDependency("org.junit", "junit", "2.0");
 
-        Dependency wrongDepFromReactor = createDependency( "org.apache.enforcer", "m2", "1.1-SNAPSHOT" );
-        List<Dependency> depList = Arrays.asList( goodDependency, wrongDepFromReactor );
-        when( mp2.getDependencies() ).thenReturn( depList );
+            Dependency wrongDepFromReactor = createDependency("org.apache.enforcer", "m2", "1.1-SNAPSHOT");
+            List<Dependency> depList = Arrays.asList(goodDependency, wrongDepFromReactor);
+            when(mp2.getDependencies()).thenReturn(depList);
 
-        MavenProject mp3 = createProjectChild2( mp1 );
+            MavenProject mp3 = createProjectChild2(mp1);
 
-        List<MavenProject> theList = Arrays.asList( mp1, mp2, mp3 );
-        setupSortedProjects( theList );
+            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(theList);
 
-        rule.execute( helper );
+            rule.execute(helper);
+
+            // intentionally no assertTrue() cause we expect getting an exception.
+        });
 
         // intentionally no assertTrue() cause we expect getting an exception.
     }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireActiveProfileTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireActiveProfileTest.java
@@ -86,14 +86,14 @@ public class RequireActiveProfileTest
     public void testNoActiveProfileButTheRuleRequestedAnActiveProfile()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            when(project.getInjectedProfileIds()).thenReturn(Collections.<String, List<String>>emptyMap());
+        assertThrows( EnforcerRuleException.class, () -> {
+            when( project.getInjectedProfileIds() ).thenReturn( Collections.<String, List<String>>emptyMap() );
 
-            rule.setProfiles("profile-2");
+            rule.setProfiles( "profile-2" );
 
-            rule.execute(helper);
+            rule.execute( helper );
             // intentionally no assertTrue(...)
-        });
+        } );
         // intentionally no assertTrue(...)
     }
 
@@ -101,15 +101,15 @@ public class RequireActiveProfileTest
     public void testNoActiveProfileButWeExpectToGetAnExceptionWithAll()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            when(project.getInjectedProfileIds()).thenReturn(Collections.<String, List<String>>emptyMap());
+        assertThrows( EnforcerRuleException.class, () -> {
+            when( project.getInjectedProfileIds() ).thenReturn( Collections.<String, List<String>>emptyMap() );
 
-            rule.setProfiles("profile-2");
-            rule.setAll(true);
+            rule.setProfiles( "profile-2" );
+            rule.setAll( true );
 
-            rule.execute(helper);
+            rule.execute( helper );
             // intentionally no assertTrue(...)
-        });
+        } );
         // intentionally no assertTrue(...)
     }
 
@@ -132,7 +132,7 @@ public class RequireActiveProfileTest
         throws EnforcerRuleException
     {
         Map<String, List<String>> profiles =
-                        Collections.singletonMap( "pom", Arrays.asList( "profile-1", "profile-2" ) );
+            Collections.singletonMap( "pom", Arrays.asList( "profile-1", "profile-2" ) );
 
         when( project.getInjectedProfileIds() ).thenReturn( profiles );
 
@@ -146,18 +146,18 @@ public class RequireActiveProfileTest
     public void testTwoActiveProfilesWithTwoRequiredProfilesWhereOneOfThemIsNotPartOfTheActiveProfiles()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             Map<String, List<String>> profiles =
-                    Collections.singletonMap("pom", Arrays.asList("profile-X", "profile-Y"));
+                Collections.singletonMap( "pom", Arrays.asList( "profile-X", "profile-Y" ) );
 
-            when(project.getInjectedProfileIds()).thenReturn(profiles);
+            when( project.getInjectedProfileIds() ).thenReturn( profiles );
 
-            rule.setProfiles("profile-Z,profile-X");
-            rule.setAll(true);
+            rule.setProfiles( "profile-Z,profile-X" );
+            rule.setAll( true );
 
-            rule.execute(helper);
+            rule.execute( helper );
             // intentionally no assertTrue(..)
-        });
+        } );
         // intentionally no assertTrue(..)
     }
 
@@ -165,18 +165,17 @@ public class RequireActiveProfileTest
     public void testOneActiveProfilesWithTwoRequiredProfiles()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            Map<String, List<String>> profiles =
-                    Collections.singletonMap("pom", Arrays.asList("profile-X"));
+        assertThrows( EnforcerRuleException.class, () -> {
+            Map<String, List<String>> profiles = Collections.singletonMap( "pom", Arrays.asList( "profile-X" ) );
 
-            when(project.getInjectedProfileIds()).thenReturn(profiles);
+            when( project.getInjectedProfileIds() ).thenReturn( profiles );
 
-            rule.setProfiles("profile-X,profile-Y");
-            rule.setAll(true);
+            rule.setProfiles( "profile-X,profile-Y" );
+            rule.setAll( true );
 
-            rule.execute(helper);
+            rule.execute( helper );
             // intentionally no assertTrue(..)
-        });
+        } );
         // intentionally no assertTrue(..)
     }
 
@@ -184,8 +183,7 @@ public class RequireActiveProfileTest
     public void testOneActiveProfileWithTwoProfilesButNotAll()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        Map<String, List<String>> profiles =
-                        Collections.singletonMap( "pom", Arrays.asList( "profile-X" ) );
+        Map<String, List<String>> profiles = Collections.singletonMap( "pom", Arrays.asList( "profile-X" ) );
 
         when( project.getInjectedProfileIds() ).thenReturn( profiles );
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireActiveProfileTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireActiveProfileTest.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Check the profile rule.
@@ -47,7 +49,7 @@ public class RequireActiveProfileTest
 
     private RequireActiveProfile rule;
 
-    @Before
+    @BeforeEach
     public void before()
         throws ExpressionEvaluationException
     {
@@ -80,28 +82,34 @@ public class RequireActiveProfileTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testNoActiveProfileButTheRuleRequestedAnActiveProfile()
         throws EnforcerRuleException
     {
-        when( project.getInjectedProfileIds() ).thenReturn( Collections.<String, List<String>>emptyMap() );
+        assertThrows(EnforcerRuleException.class, () -> {
+            when(project.getInjectedProfileIds()).thenReturn(Collections.<String, List<String>>emptyMap());
 
-        rule.setProfiles( "profile-2" );
+            rule.setProfiles("profile-2");
 
-        rule.execute( helper );
+            rule.execute(helper);
+            // intentionally no assertTrue(...)
+        });
         // intentionally no assertTrue(...)
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testNoActiveProfileButWeExpectToGetAnExceptionWithAll()
         throws EnforcerRuleException
     {
-        when( project.getInjectedProfileIds() ).thenReturn( Collections.<String, List<String>>emptyMap() );
+        assertThrows(EnforcerRuleException.class, () -> {
+            when(project.getInjectedProfileIds()).thenReturn(Collections.<String, List<String>>emptyMap());
 
-        rule.setProfiles( "profile-2" );
-        rule.setAll( true );
+            rule.setProfiles("profile-2");
+            rule.setAll(true);
 
-        rule.execute( helper );
+            rule.execute(helper);
+            // intentionally no assertTrue(...)
+        });
         // intentionally no assertTrue(...)
     }
 
@@ -134,35 +142,41 @@ public class RequireActiveProfileTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testTwoActiveProfilesWithTwoRequiredProfilesWhereOneOfThemIsNotPartOfTheActiveProfiles()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        Map<String, List<String>> profiles =
-                        Collections.singletonMap( "pom", Arrays.asList( "profile-X", "profile-Y" ) );
+        assertThrows(EnforcerRuleException.class, () -> {
+            Map<String, List<String>> profiles =
+                    Collections.singletonMap("pom", Arrays.asList("profile-X", "profile-Y"));
 
-        when( project.getInjectedProfileIds() ).thenReturn( profiles );
+            when(project.getInjectedProfileIds()).thenReturn(profiles);
 
-        rule.setProfiles( "profile-Z,profile-X" );
-        rule.setAll( true );
+            rule.setProfiles("profile-Z,profile-X");
+            rule.setAll(true);
 
-        rule.execute( helper );
+            rule.execute(helper);
+            // intentionally no assertTrue(..)
+        });
         // intentionally no assertTrue(..)
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testOneActiveProfilesWithTwoRequiredProfiles()
         throws EnforcerRuleException, ExpressionEvaluationException
     {
-        Map<String, List<String>> profiles =
-                        Collections.singletonMap( "pom", Arrays.asList( "profile-X" ) );
+        assertThrows(EnforcerRuleException.class, () -> {
+            Map<String, List<String>> profiles =
+                    Collections.singletonMap("pom", Arrays.asList("profile-X"));
 
-        when( project.getInjectedProfileIds() ).thenReturn( profiles );
+            when(project.getInjectedProfileIds()).thenReturn(profiles);
 
-        rule.setProfiles( "profile-X,profile-Y" );
-        rule.setAll( true );
+            rule.setProfiles("profile-X,profile-Y");
+            rule.setAll(true);
 
-        rule.execute( helper );
+            rule.execute(helper);
+            // intentionally no assertTrue(..)
+        });
         // intentionally no assertTrue(..)
     }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequirePrerequisiteTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequirePrerequisiteTest.java
@@ -26,13 +26,15 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Prerequisites;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RequirePrerequisiteTest
 {
@@ -40,7 +42,7 @@ public class RequirePrerequisiteTest
 
     private EnforcerRuleHelper helper;
 
-    @Before
+    @BeforeEach
     public void before()
         throws ExpressionEvaluationException
     {
@@ -51,12 +53,14 @@ public class RequirePrerequisiteTest
         when( helper.evaluate( "${project}" ) ).thenReturn( project );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testNoPrerequisite()
         throws Exception
     {
-        RequirePrerequisite rule = new RequirePrerequisite();
-        rule.execute( helper );
+        assertThrows(EnforcerRuleException.class, () -> {
+            RequirePrerequisite rule = new RequirePrerequisite();
+            rule.execute(helper);
+        });
     }
 
     @Test
@@ -69,41 +73,47 @@ public class RequirePrerequisiteTest
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testLowerMavenPrerequisite()
         throws Exception
     {
-        when( project.getPrerequisites() ).thenReturn( new Prerequisites() );
+        assertThrows(EnforcerRuleException.class, () -> {
+            when(project.getPrerequisites()).thenReturn(new Prerequisites());
 
-        RequirePrerequisite rule = new RequirePrerequisite();
-        rule.setMavenVersion( "3.0" );
-        rule.execute( helper );
+            RequirePrerequisite rule = new RequirePrerequisite();
+            rule.setMavenVersion("3.0");
+            rule.execute(helper);
+        });
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testLowerMavenRangePrerequisite()
         throws Exception
     {
-        when( project.getPrerequisites() ).thenReturn( new Prerequisites() );
+        assertThrows(EnforcerRuleException.class, () -> {
+            when(project.getPrerequisites()).thenReturn(new Prerequisites());
 
-        RequirePrerequisite rule = new RequirePrerequisite();
-        rule.setMavenVersion( "[3.0,)" );
+            RequirePrerequisite rule = new RequirePrerequisite();
+            rule.setMavenVersion("[3.0,)");
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testMavenRangesPrerequisite()
         throws Exception
     {
-        Prerequisites prerequisites = new Prerequisites();
-        prerequisites.setMaven( "2.2.0" );
-        when( project.getPrerequisites() ).thenReturn( prerequisites );
+        assertThrows(EnforcerRuleException.class, () -> {
+            Prerequisites prerequisites = new Prerequisites();
+            prerequisites.setMaven("2.2.0");
+            when(project.getPrerequisites()).thenReturn(prerequisites);
 
-        RequirePrerequisite rule = new RequirePrerequisite();
-        rule.setMavenVersion( "[2.0.6,2.1.0),(2.1.0,2.2.0),(2.2.0,)" );
+            RequirePrerequisite rule = new RequirePrerequisite();
+            rule.setMavenVersion("[2.0.6,2.1.0),(2.1.0,2.2.0),(2.2.0,)");
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
     @Test
@@ -135,15 +145,17 @@ public class RequirePrerequisiteTest
         verify( log ).debug( "Packaging is pom, skipping requirePrerequisite rule" );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testMatchingPackagings()
         throws Exception
     {
-        when( project.getPackaging() ).thenReturn( "maven-plugin" );
+        assertThrows(EnforcerRuleException.class, () -> {
+            when(project.getPackaging()).thenReturn("maven-plugin");
 
-        RequirePrerequisite rule = new RequirePrerequisite();
-        rule.setPackagings( Collections.singletonList( "maven-plugin" ) );
-        rule.execute( helper );
+            RequirePrerequisite rule = new RequirePrerequisite();
+            rule.setPackagings(Collections.singletonList("maven-plugin"));
+            rule.execute(helper);
+        });
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequirePrerequisiteTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequirePrerequisiteTest.java
@@ -57,10 +57,10 @@ public class RequirePrerequisiteTest
     public void testNoPrerequisite()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             RequirePrerequisite rule = new RequirePrerequisite();
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     @Test
@@ -77,43 +77,43 @@ public class RequirePrerequisiteTest
     public void testLowerMavenPrerequisite()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            when(project.getPrerequisites()).thenReturn(new Prerequisites());
+        assertThrows( EnforcerRuleException.class, () -> {
+            when( project.getPrerequisites() ).thenReturn( new Prerequisites() );
 
             RequirePrerequisite rule = new RequirePrerequisite();
-            rule.setMavenVersion("3.0");
-            rule.execute(helper);
-        });
+            rule.setMavenVersion( "3.0" );
+            rule.execute( helper );
+        } );
     }
 
     @Test
     public void testLowerMavenRangePrerequisite()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            when(project.getPrerequisites()).thenReturn(new Prerequisites());
+        assertThrows( EnforcerRuleException.class, () -> {
+            when( project.getPrerequisites() ).thenReturn( new Prerequisites() );
 
             RequirePrerequisite rule = new RequirePrerequisite();
-            rule.setMavenVersion("[3.0,)");
+            rule.setMavenVersion( "[3.0,)" );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     @Test
     public void testMavenRangesPrerequisite()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             Prerequisites prerequisites = new Prerequisites();
-            prerequisites.setMaven("2.2.0");
-            when(project.getPrerequisites()).thenReturn(prerequisites);
+            prerequisites.setMaven( "2.2.0" );
+            when( project.getPrerequisites() ).thenReturn( prerequisites );
 
             RequirePrerequisite rule = new RequirePrerequisite();
-            rule.setMavenVersion("[2.0.6,2.1.0),(2.1.0,2.2.0),(2.2.0,)");
+            rule.setMavenVersion( "[2.0.6,2.1.0),(2.1.0,2.2.0),(2.2.0,)" );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     @Test
@@ -149,13 +149,13 @@ public class RequirePrerequisiteTest
     public void testMatchingPackagings()
         throws Exception
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            when(project.getPackaging()).thenReturn("maven-plugin");
+        assertThrows( EnforcerRuleException.class, () -> {
+            when( project.getPackaging() ).thenReturn( "maven-plugin" );
 
             RequirePrerequisite rule = new RequirePrerequisite();
-            rule.setPackagings(Collections.singletonList("maven-plugin"));
-            rule.execute(helper);
-        });
+            rule.setPackagings( Collections.singletonList( "maven-plugin" ) );
+            rule.execute( helper );
+        } );
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDepsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDepsTest.java
@@ -1,6 +1,6 @@
 package org.apache.maven.plugins.enforcer;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -21,7 +21,7 @@ import org.junit.Assert;
  * under the License.
  */
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -47,7 +47,7 @@ public class RequireUpperBoundDepsTest
 
         try {
           rule.execute( helper );
-          Assert.fail("Did not detect upper bounds error");
+          Assertions.fail("Did not detect upper bounds error");
         }
         catch ( EnforcerRuleException ex ) {
             assertThat( ex.getMessage(), containsString( "groupId:artifactId:version:classifier" ) );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDepsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/RequireUpperBoundDepsTest.java
@@ -36,7 +36,8 @@ public class RequireUpperBoundDepsTest
 {
 
     @Test
-    public void testRule() throws IOException
+    public void testRule()
+        throws IOException
     {
         ArtifactStubFactory factory = new ArtifactStubFactory();
         MockProject project = new MockProject();
@@ -45,11 +46,13 @@ public class RequireUpperBoundDepsTest
         project.setDependencyArtifacts( factory.getScopedArtifacts() );
         RequireUpperBoundDeps rule = new RequireUpperBoundDeps();
 
-        try {
-          rule.execute( helper );
-          Assertions.fail("Did not detect upper bounds error");
+        try
+        {
+            rule.execute( helper );
+            Assertions.fail( "Did not detect upper bounds error" );
         }
-        catch ( EnforcerRuleException ex ) {
+        catch ( EnforcerRuleException ex )
+        {
             assertThat( ex.getMessage(), containsString( "groupId:artifactId:version:classifier" ) );
         }
     }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAbstractVersionEnforcer.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAbstractVersionEnforcer.java
@@ -49,41 +49,54 @@ public class TestAbstractVersionEnforcer
     {
         ArtifactVersion version = new DefaultArtifactVersion( "2.0.5" );
         // test ranges
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.5,)" ), version ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,)" ), version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.5,)" ),
+                                                             version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,)" ),
+                                                             version ) );
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,2.0.5]" ),
                                                              version ) );
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,2.0.6]" ),
                                                              version ) );
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,2.0.6)" ),
                                                              version ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0,)" ), version ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.0,)" ), version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0,)" ),
+                                                             version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.0,)" ),
+                                                             version ) );
         // not matching versions
         assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.4,2.0.5)" ),
                                                               version ) );
-        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.6,)" ), version ) );
-        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "(2.0.5,)" ), version ) );
+        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.0.6,)" ),
+                                                              version ) );
+        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "(2.0.5,)" ),
+                                                              version ) );
 
         // test singular versions -> 2.0.5 == [2.0.5,) or x >= 2.0.5
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "2.0" ), version ) );
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "2.0.4" ), version ) );
         assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "2.0.5" ), version ) );
 
-        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "2.0.6" ), version ) );
+        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "2.0.6" ),
+                                                              version ) );
 
         version = new DefaultArtifactVersion( "1.5.0-7" );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5.0,)" ), version ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5,1.6)" ), version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5.0,)" ),
+                                                             version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5,1.6)" ),
+                                                             version ) );
 
         version = new DefaultArtifactVersion( RequireJavaVersion.normalizeJDKVersion( "1.5.0-07" ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5.0,)" ), version ) );
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5,1.6)" ), version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5.0,)" ),
+                                                             version ) );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[1.5,1.6)" ),
+                                                             version ) );
 
-        //MENFORCER-50
-        version = new DefaultArtifactVersion ("2.1.0-M1-RC12");
-        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.1.0-M1-RC12,)" ), version ) );
-        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.1.0-M1,)" ), version ) );
+        // MENFORCER-50
+        version = new DefaultArtifactVersion( "2.1.0-M1-RC12" );
+        assertTrue( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.1.0-M1-RC12,)" ),
+                                                             version ) );
+        assertFalse( AbstractVersionEnforcer.containsVersion( VersionRange.createFromVersionSpec( "[2.1.0-M1,)" ),
+                                                              version ) );
 
     }
 
@@ -96,7 +109,8 @@ public class TestAbstractVersionEnforcer
      * @param range the range
      * @param version the version
      */
-    private void enforceFalse( AbstractVersionEnforcer rule, Log log, String var, String range, ArtifactVersion version )
+    private void enforceFalse( AbstractVersionEnforcer rule, Log log, String var, String range,
+                               ArtifactVersion version )
     {
         try
         {

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAbstractVersionEnforcer.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAbstractVersionEnforcer.java
@@ -19,9 +19,7 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -30,7 +28,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestAbstractVersionEnforcer.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysFail.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysFail.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test AlwaysFail rule.
+ * 
  * @author Ben Lidgey
  * @see AlwaysFail
  */

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysFail.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysFail.java
@@ -19,11 +19,11 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test AlwaysFail rule.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysPass.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysPass.java
@@ -24,13 +24,15 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test AlwaysPass rule.
+ * 
  * @author Ben Lidgey
  * @see AlwaysPass
  */
 public class TestAlwaysPass
 {
     @Test
-    public void testExecute() throws EnforcerRuleException
+    public void testExecute()
+        throws EnforcerRuleException
     {
         AlwaysPass rule = new AlwaysPass();
         rule.execute( EnforcerTestUtils.getHelper() );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysPass.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestAlwaysPass.java
@@ -20,7 +20,7 @@ package org.apache.maven.plugins.enforcer;
  */
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test AlwaysPass rule.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
@@ -99,54 +99,54 @@ public class TestBannedDependencies
         public void testGroupIdArtifactIdVersion()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("testGroupId:release:1.0");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "testGroupId:release:1.0" );
+            } );
         }
 
         @Test
         public void testGroupIdArtifactId()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("testGroupId:release");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "testGroupId:release" );
+            } );
         }
 
         @Test
         public void testGroupId()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("testGroupId");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "testGroupId" );
+            } );
         }
 
         @Test
         public void testSpaceTrimmingGroupIdArtifactIdVersion()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("  testGroupId  :  release   :   1.0    ");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "  testGroupId  :  release   :   1.0    " );
+            } );
         }
 
         @Test
         public void groupIdArtifactIdVersionType()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("g:a:1.0:war");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "g:a:1.0:war" );
+            } );
         }
 
         @Test
         public void groupIdArtifactIdVersionTypeScope()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("g:a:1.0:war:compile");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "g:a:1.0:war:compile" );
+            } );
         }
 
         // @Test(expected = EnforcerRuleException.class)
@@ -186,27 +186,27 @@ public class TestBannedDependencies
         public void testWildCardForGroupIdArtifactId()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("*:release");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "*:release" );
+            } );
         }
 
         @Test
         public void testWildcardForGroupIdWildcardForArtifactIdVersion()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("*:*:1.0");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "*:*:1.0" );
+            } );
         }
 
         @Test
         public void testWildcardForGroupIdArtifactIdWildcardForVersion()
             throws Exception
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("*:release:*");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "*:release:*" );
+            } );
         }
 
     }
@@ -234,27 +234,27 @@ public class TestBannedDependencies
         public void groupIdArtifactIdWithWildcard()
             throws EnforcerRuleException
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("testGroupId:re*");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "testGroupId:re*" );
+            } );
         }
 
         @Test
         public void groupIdArtifactIdVersionTypeWildcardScope()
             throws EnforcerRuleException
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("g:a:1.0:war:co*");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "g:a:1.0:war:co*" );
+            } );
         }
 
         @Test
         public void groupIdArtifactIdVersionWildcardTypeScope()
             throws EnforcerRuleException
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addExcludeAndRunRule("g:a:1.0:w*:compile");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule( "g:a:1.0:w*:compile" );
+            } );
         }
     }
 
@@ -280,18 +280,18 @@ public class TestBannedDependencies
         public void onlyThreeColonsWithoutAnythingElse()
             throws EnforcerRuleException
         {
-            assertThrows(IllegalArgumentException.class, () -> {
-                addExcludeAndRunRule(":::");
-            });
+            assertThrows( IllegalArgumentException.class, () -> {
+                addExcludeAndRunRule( ":::" );
+            } );
         }
 
         @Test
         public void onlySevenColonsWithoutAnythingElse()
             throws EnforcerRuleException
         {
-            assertThrows(IllegalArgumentException.class, () -> {
-                addExcludeAndRunRule(":::::::");
-            });
+            assertThrows( IllegalArgumentException.class, () -> {
+                addExcludeAndRunRule( ":::::::" );
+            } );
         }
 
     }
@@ -332,9 +332,9 @@ public class TestBannedDependencies
         public void includeEverythingAndExcludeEveryGroupIdAndScopeRuntimeYYYY()
             throws EnforcerRuleException
         {
-            assertThrows(EnforcerRuleException.class, () -> {
-                addIncludeExcludeAndRunRule("*:test", "*:runtime");
-            });
+            assertThrows( EnforcerRuleException.class, () -> {
+                addIncludeExcludeAndRunRule( "*:test", "*:runtime" );
+            } );
         }
     }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedDependencies.java
@@ -22,17 +22,16 @@ package org.apache.maven.plugins.enforcer;
 import java.io.IOException;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The Class TestBannedDependencies.
- * 
+ *
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
-@RunWith( Enclosed.class )
 public class TestBannedDependencies
 {
 
@@ -40,7 +39,7 @@ public class TestBannedDependencies
     {
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -82,7 +81,7 @@ public class TestBannedDependencies
 
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -96,46 +95,58 @@ public class TestBannedDependencies
             this.setup.addExcludeAndRunRule( toAdd );
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testGroupIdArtifactIdVersion()
             throws Exception
         {
-            addExcludeAndRunRule( "testGroupId:release:1.0" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("testGroupId:release:1.0");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testGroupIdArtifactId()
             throws Exception
         {
-            addExcludeAndRunRule( "testGroupId:release" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("testGroupId:release");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testGroupId()
             throws Exception
         {
-            addExcludeAndRunRule( "testGroupId" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("testGroupId");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testSpaceTrimmingGroupIdArtifactIdVersion()
             throws Exception
         {
-            addExcludeAndRunRule( "  testGroupId  :  release   :   1.0    " );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("  testGroupId  :  release   :   1.0    ");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void groupIdArtifactIdVersionType()
             throws Exception
         {
-            addExcludeAndRunRule( "g:a:1.0:war" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("g:a:1.0:war");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void groupIdArtifactIdVersionTypeScope()
             throws Exception
         {
-            addExcludeAndRunRule( "g:a:1.0:war:compile" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("g:a:1.0:war:compile");
+            });
         }
 
         // @Test(expected = EnforcerRuleException.class)
@@ -150,7 +161,7 @@ public class TestBannedDependencies
 
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -171,25 +182,31 @@ public class TestBannedDependencies
             addExcludeAndRunRule( "*:release:1.2" );
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testWildCardForGroupIdArtifactId()
             throws Exception
         {
-            addExcludeAndRunRule( "*:release" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("*:release");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testWildcardForGroupIdWildcardForArtifactIdVersion()
             throws Exception
         {
-            addExcludeAndRunRule( "*:*:1.0" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("*:*:1.0");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void testWildcardForGroupIdArtifactIdWildcardForVersion()
             throws Exception
         {
-            addExcludeAndRunRule( "*:release:*" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("*:release:*");
+            });
         }
 
     }
@@ -199,7 +216,7 @@ public class TestBannedDependencies
 
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -213,25 +230,31 @@ public class TestBannedDependencies
             this.setup.addExcludeAndRunRule( toAdd );
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void groupIdArtifactIdWithWildcard()
             throws EnforcerRuleException
         {
-            addExcludeAndRunRule( "testGroupId:re*" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("testGroupId:re*");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void groupIdArtifactIdVersionTypeWildcardScope()
             throws EnforcerRuleException
         {
-            addExcludeAndRunRule( "g:a:1.0:war:co*" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("g:a:1.0:war:co*");
+            });
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void groupIdArtifactIdVersionWildcardTypeScope()
             throws EnforcerRuleException
         {
-            addExcludeAndRunRule( "g:a:1.0:w*:compile" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addExcludeAndRunRule("g:a:1.0:w*:compile");
+            });
         }
     }
 
@@ -239,7 +262,7 @@ public class TestBannedDependencies
     {
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -253,18 +276,22 @@ public class TestBannedDependencies
             this.setup.addExcludeAndRunRule( toAdd );
         }
 
-        @Test( expected = IllegalArgumentException.class )
+        @Test
         public void onlyThreeColonsWithoutAnythingElse()
             throws EnforcerRuleException
         {
-            addExcludeAndRunRule( ":::" );
+            assertThrows(IllegalArgumentException.class, () -> {
+                addExcludeAndRunRule(":::");
+            });
         }
 
-        @Test( expected = IllegalArgumentException.class )
+        @Test
         public void onlySevenColonsWithoutAnythingElse()
             throws EnforcerRuleException
         {
-            addExcludeAndRunRule( ":::::::" );
+            assertThrows(IllegalArgumentException.class, () -> {
+                addExcludeAndRunRule(":::::::");
+            });
         }
 
     }
@@ -273,7 +300,7 @@ public class TestBannedDependencies
     {
         private BannedDependenciesTestSetup setup;
 
-        @Before
+        @BeforeEach
         public void beforeMethod()
             throws IOException
         {
@@ -301,11 +328,13 @@ public class TestBannedDependencies
             addIncludeExcludeAndRunRule( "*", "*:runtime" );
         }
 
-        @Test( expected = EnforcerRuleException.class )
+        @Test
         public void includeEverythingAndExcludeEveryGroupIdAndScopeRuntimeYYYY()
             throws EnforcerRuleException
         {
-            addIncludeExcludeAndRunRule( "*:test", "*:runtime" );
+            assertThrows(EnforcerRuleException.class, () -> {
+                addIncludeExcludeAndRunRule("*:test", "*:runtime");
+            });
         }
     }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestBannedRepositories.java
@@ -26,10 +26,11 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+
 /**
  * Test the "banned repositories" rule.
  * 
@@ -43,7 +44,7 @@ public class TestBannedRepositories
 
     private MockProject project;
 
-    @Before
+    @BeforeEach
     public void setUp()
         throws Exception
     {

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestEvaluateBeanshell.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestEvaluateBeanshell.java
@@ -19,11 +19,12 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import junit.framework.TestCase;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,7 +34,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * The Class TestEvaluateBeanshell.
@@ -41,10 +44,10 @@ import static org.mockito.Mockito.*;
  * @author hugonnem
  */
 public class TestEvaluateBeanshell
-    extends TestCase
 {
     private MockProject project;
 
+    @BeforeEach
     public void setUp()
     {
         project = new MockProject();
@@ -53,10 +56,11 @@ public class TestEvaluateBeanshell
 
     /**
      * Test rule.
-     * 
+     *
      */
+    @Test
     public void testRulePass()
-        throws Exception
+            throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should not be set
@@ -67,8 +71,9 @@ public class TestEvaluateBeanshell
         rule.execute( helper );
     }
 
+    @Test
     public void testRuleFail()
-        throws Exception
+            throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should be set by the surefire
@@ -88,8 +93,9 @@ public class TestEvaluateBeanshell
         }
     }
 
+    @Test
     public void testRuleFailNoMessage()
-        throws Exception
+            throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should be set by the surefire
@@ -108,8 +114,9 @@ public class TestEvaluateBeanshell
         }
     }
 
+    @Test
     public void testRuleInvalidExpression()
-        throws Exception
+            throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         rule.setCondition( "${env} == null" );
@@ -129,8 +136,9 @@ public class TestEvaluateBeanshell
         }
     }
 
+    @Test
     public void testRuleInvalidBeanshell()
-        throws Exception
+            throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         rule.setCondition( "this is not valid beanshell" );
@@ -148,6 +156,7 @@ public class TestEvaluateBeanshell
     }
 
 
+    @Test
     public void testRuleCanExecuteMultipleThreads() throws Exception {
         final String condition = "String property1 = \"${property1}\";\n" +
                 "(property1.equals(\"prop0\") && \"${property2}\".equals(\"prop0\"))\n" +
@@ -244,13 +253,13 @@ public class TestEvaluateBeanshell
                 });
             }
             // wait until all threads are ready
-            assertTrue("Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent", allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS));
+            assertTrue(allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS), "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent");
             // start all test runners
             afterInitBlocker.countDown();
-            assertTrue("Timeout! More than" + maxTimeoutSeconds + "seconds", allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+            assertTrue(allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS), "Timeout! More than" + maxTimeoutSeconds + "seconds");
         } finally {
             threadPool.shutdownNow();
         }
-        assertTrue("Failed with exception(s)" + exceptions, exceptions.isEmpty());
+        assertTrue(exceptions.isEmpty(), "Failed with exception(s)" + exceptions);
     }
 }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestEvaluateBeanshell.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestEvaluateBeanshell.java
@@ -56,11 +56,10 @@ public class TestEvaluateBeanshell
 
     /**
      * Test rule.
-     *
      */
     @Test
     public void testRulePass()
-            throws Exception
+        throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should not be set
@@ -73,7 +72,7 @@ public class TestEvaluateBeanshell
 
     @Test
     public void testRuleFail()
-            throws Exception
+        throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should be set by the surefire
@@ -95,7 +94,7 @@ public class TestEvaluateBeanshell
 
     @Test
     public void testRuleFailNoMessage()
-            throws Exception
+        throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         // this property should be set by the surefire
@@ -116,7 +115,7 @@ public class TestEvaluateBeanshell
 
     @Test
     public void testRuleInvalidExpression()
-            throws Exception
+        throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         rule.setCondition( "${env} == null" );
@@ -138,7 +137,7 @@ public class TestEvaluateBeanshell
 
     @Test
     public void testRuleInvalidBeanshell()
-            throws Exception
+        throws Exception
     {
         EvaluateBeanshell rule = new EvaluateBeanshell();
         rule.setCondition( "this is not valid beanshell" );
@@ -155,111 +154,142 @@ public class TestEvaluateBeanshell
         }
     }
 
-
     @Test
-    public void testRuleCanExecuteMultipleThreads() throws Exception {
-        final String condition = "String property1 = \"${property1}\";\n" +
-                "(property1.equals(\"prop0\") && \"${property2}\".equals(\"prop0\"))\n" +
-                "|| (property1.equals(\"prop1\") && \"${property2}\".equals(\"prop1\"))\n" +
-                "|| (property1.equals(\"prop2\") && \"${property2}\".equals(\"prop2\"))\n";
+    public void testRuleCanExecuteMultipleThreads()
+        throws Exception
+    {
+        final String condition = "String property1 = \"${property1}\";\n"
+            + "(property1.equals(\"prop0\") && \"${property2}\".equals(\"prop0\"))\n"
+            + "|| (property1.equals(\"prop1\") && \"${property2}\".equals(\"prop1\"))\n"
+            + "|| (property1.equals(\"prop2\") && \"${property2}\".equals(\"prop2\"))\n";
 
         final List<Runnable> runnables = new ArrayList<>();
 
-        runnables.add(new Runnable() {
+        runnables.add( new Runnable()
+        {
             @Override
-            public void run() {
+            public void run()
+            {
                 final int threadNumber = 0;
                 MockProject multiProject = new MockProject();
-                multiProject.setProperty("property1", "prop" + threadNumber);
-                multiProject.setProperty("property2", "prop" + threadNumber);
+                multiProject.setProperty( "property1", "prop" + threadNumber );
+                multiProject.setProperty( "property2", "prop" + threadNumber );
 
                 EvaluateBeanshell rule = new EvaluateBeanshell();
-                rule.setCondition(condition);
-                rule.setMessage("Race condition in thread " + threadNumber);
-                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper(multiProject);
-                try {
-                    rule.execute(helper);
+                rule.setCondition( condition );
+                rule.setMessage( "Race condition in thread " + threadNumber );
+                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper( multiProject );
+                try
+                {
+                    rule.execute( helper );
 
-                } catch (EnforcerRuleException e) {
-                    throw new RuntimeException(e);
+                }
+                catch ( EnforcerRuleException e )
+                {
+                    throw new RuntimeException( e );
                 }
             }
-        });
-        runnables.add(new Runnable() {
+        } );
+        runnables.add( new Runnable()
+        {
             @Override
-            public void run() {
+            public void run()
+            {
                 final int threadNumber = 1;
                 MockProject multiProject = new MockProject();
-                multiProject.setProperty("property1", "prop" + threadNumber);
-                multiProject.setProperty("property2", "prop" + threadNumber);
+                multiProject.setProperty( "property1", "prop" + threadNumber );
+                multiProject.setProperty( "property2", "prop" + threadNumber );
 
                 EvaluateBeanshell rule = new EvaluateBeanshell();
-                rule.setCondition(condition);
-                rule.setMessage("Race condition in thread " + threadNumber);
-                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper(multiProject);
-                try {
-                    rule.execute(helper);
+                rule.setCondition( condition );
+                rule.setMessage( "Race condition in thread " + threadNumber );
+                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper( multiProject );
+                try
+                {
+                    rule.execute( helper );
 
-                } catch (EnforcerRuleException e) {
-                    throw new RuntimeException(e);
+                }
+                catch ( EnforcerRuleException e )
+                {
+                    throw new RuntimeException( e );
                 }
 
             }
-        });
-        runnables.add(new Runnable() {
+        } );
+        runnables.add( new Runnable()
+        {
             @Override
-            public void run() {
+            public void run()
+            {
                 final int threadNumber = 2;
                 MockProject multiProject = new MockProject();
-                multiProject.setProperty("property1", "prop" + threadNumber);
-                multiProject.setProperty("property2", "prop" + threadNumber);
+                multiProject.setProperty( "property1", "prop" + threadNumber );
+                multiProject.setProperty( "property2", "prop" + threadNumber );
 
                 EvaluateBeanshell rule = new EvaluateBeanshell();
-                rule.setCondition(condition);
-                rule.setMessage("Race condition in thread " + threadNumber);
-                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper(multiProject);
-                try {
-                    rule.execute(helper);
-                } catch (EnforcerRuleException e) {
-                    throw new RuntimeException(e);
+                rule.setCondition( condition );
+                rule.setMessage( "Race condition in thread " + threadNumber );
+                EnforcerRuleHelper helper = EnforcerTestUtils.getHelper( multiProject );
+                try
+                {
+                    rule.execute( helper );
+                }
+                catch ( EnforcerRuleException e )
+                {
+                    throw new RuntimeException( e );
                 }
             }
-        });
+        } );
 
-        assertConcurrent( runnables, 4);
+        assertConcurrent( runnables, 4 );
     }
 
-    private static void assertConcurrent(final List<? extends Runnable> runnables, final int maxTimeoutSeconds) throws InterruptedException {
+    private static void assertConcurrent( final List<? extends Runnable> runnables, final int maxTimeoutSeconds )
+        throws InterruptedException
+    {
         final int numThreads = runnables.size();
-        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
-        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
-        try {
-            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
-            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
-            final CountDownLatch allDone = new CountDownLatch(numThreads);
-            for (final Runnable submittedTestRunnable : runnables) {
-                threadPool.submit(new Runnable() {
-                    public void run() {
+        final List<Throwable> exceptions = Collections.synchronizedList( new ArrayList<Throwable>() );
+        final ExecutorService threadPool = Executors.newFixedThreadPool( numThreads );
+        try
+        {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch( numThreads );
+            final CountDownLatch afterInitBlocker = new CountDownLatch( 1 );
+            final CountDownLatch allDone = new CountDownLatch( numThreads );
+            for ( final Runnable submittedTestRunnable : runnables )
+            {
+                threadPool.submit( new Runnable()
+                {
+                    public void run()
+                    {
                         allExecutorThreadsReady.countDown();
-                        try {
+                        try
+                        {
                             afterInitBlocker.await();
                             submittedTestRunnable.run();
-                        } catch (final Throwable e) {
-                            exceptions.add(e);
-                        } finally {
+                        }
+                        catch ( final Throwable e )
+                        {
+                            exceptions.add( e );
+                        }
+                        finally
+                        {
                             allDone.countDown();
                         }
                     }
-                });
+                } );
             }
             // wait until all threads are ready
-            assertTrue(allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS), "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent");
+            assertTrue( allExecutorThreadsReady.await( runnables.size() * 10, TimeUnit.MILLISECONDS ),
+                        "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent" );
             // start all test runners
             afterInitBlocker.countDown();
-            assertTrue(allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS), "Timeout! More than" + maxTimeoutSeconds + "seconds");
-        } finally {
+            assertTrue( allDone.await( maxTimeoutSeconds, TimeUnit.SECONDS ),
+                        "Timeout! More than" + maxTimeoutSeconds + "seconds" );
+        }
+        finally
+        {
             threadPool.shutdownNow();
         }
-        assertTrue(exceptions.isEmpty(), "Failed with exception(s)" + exceptions);
+        assertTrue( exceptions.isEmpty(), "Failed with exception(s)" + exceptions );
     }
 }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestMavenVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestMavenVersion.java
@@ -81,7 +81,8 @@ public class TestMavenVersion
      * @throws EnforcerRuleException the enforcer rule exception
      */
     @Test
-    public void checkRequireVersionMatrix() throws EnforcerRuleException, ExpressionEvaluationException
+    public void checkRequireVersionMatrix()
+        throws EnforcerRuleException, ExpressionEvaluationException
     {
         RequireMavenVersion rule = new RequireMavenVersion();
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestMavenVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestMavenVersion.java
@@ -24,11 +24,11 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * The Class TestMavenVersion.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireEnvironmentVariable.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireEnvironmentVariable.java
@@ -19,11 +19,11 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link RequireEnvironmentVariable}}

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFileChecksum.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFileChecksum.java
@@ -48,7 +48,7 @@ public class TestRequireFileChecksum
     public void testFileChecksumMd5()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -62,7 +62,7 @@ public class TestRequireFileChecksum
     public void testFileChecksumMd5UpperCase()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -77,15 +77,15 @@ public class TestRequireFileChecksum
         throws IOException, EnforcerRuleException
     {
         File f = new File( "nonExistent" );
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            rule.setFile(f);
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
-            rule.setType("md5");
+            rule.setFile( f );
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("File does not exist: " + f.getAbsolutePath()));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "File does not exist: " + f.getAbsolutePath() ) );
     }
 
     @Test
@@ -94,23 +94,23 @@ public class TestRequireFileChecksum
     {
         File f = new File( "nonExistent" );
         String configuredMessage = "testMessageFileDoesNotExist";
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            rule.setFile(f);
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
-            rule.setType("md5");
-            rule.setNonexistentFileMessage(configuredMessage);
+            rule.setFile( f );
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
+            rule.setType( "md5" );
+            rule.setNonexistentFileMessage( configuredMessage );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains(configuredMessage));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( configuredMessage ) );
     }
 
     @Test
     public void testFileChecksumMd5GivenFileIsNotReadableFailure()
         throws IOException, EnforcerRuleException
     {
-        File t = File.createTempFile("junit", null, temporaryFolder);
+        File t = File.createTempFile( "junit", null, temporaryFolder );
         File f = new File( t.getAbsolutePath() )
         {
             private static final long serialVersionUID = 6987790643999338089L;
@@ -121,15 +121,15 @@ public class TestRequireFileChecksum
                 return false;
             }
         };
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            rule.setFile(f);
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
-            rule.setType("md5");
+            rule.setFile( f );
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("Cannot read file: " + f.getAbsolutePath()));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "Cannot read file: " + f.getAbsolutePath() ) );
     }
 
     @Test
@@ -137,79 +137,80 @@ public class TestRequireFileChecksum
         throws IOException, EnforcerRuleException
     {
         File f = temporaryFolder;
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            rule.setFile(f);
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
-            rule.setType("md5");
+            rule.setFile( f );
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("Cannot calculate the checksum of directory: " + f.getAbsolutePath()));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "Cannot calculate the checksum of directory: "
+            + f.getAbsolutePath() ) );
     }
 
     @Test
     public void testFileChecksumMd5NoFileSpecifiedFailure()
         throws IOException, EnforcerRuleException
     {
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
-            rule.setType("md5");
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("Input file unspecified"));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "Input file unspecified" ) );
     }
 
     @Test
     public void testFileChecksumMd5NoChecksumSpecifiedFailure()
         throws IOException, EnforcerRuleException
     {
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            File f = File.createTempFile("junit", null, temporaryFolder);
+            File f = File.createTempFile( "junit", null, temporaryFolder );
 
-            rule.setFile(f);
-            rule.setType("md5");
+            rule.setFile( f );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("Checksum unspecified"));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "Checksum unspecified" ) );
     }
 
     @Test
     public void testFileChecksumMd5NoTypeSpecifiedFailure()
         throws IOException, EnforcerRuleException
     {
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
 
-            File f = File.createTempFile("junit", null, temporaryFolder);
+            File f = File.createTempFile( "junit", null, temporaryFolder );
 
-            rule.setFile(f);
-            rule.setChecksum("78e731027d8fd50ed642340b7c9a63b3");
+            rule.setFile( f );
+            rule.setChecksum( "78e731027d8fd50ed642340b7c9a63b3" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("Hash type unspecified"));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "Hash type unspecified" ) );
     }
 
     @Test
     public void testFileChecksumMd5ChecksumMismatchFailure()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
-            FileUtils.fileWrite(f, "message");
+        File f = File.createTempFile( "junit", null, temporaryFolder );
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
+            FileUtils.fileWrite( f, "message" );
 
-            rule.setFile(f);
-            rule.setChecksum("ffeeddccbbaa99887766554433221100");
-            rule.setType("md5");
+            rule.setFile( f );
+            rule.setChecksum( "ffeeddccbbaa99887766554433221100" );
+            rule.setType( "md5" );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains("md5 hash of " + f.getAbsolutePath()
-                + " was 78e731027d8fd50ed642340b7c9a63b3 but expected ffeeddccbbaa99887766554433221100"));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( "md5 hash of " + f.getAbsolutePath()
+            + " was 78e731027d8fd50ed642340b7c9a63b3 but expected ffeeddccbbaa99887766554433221100" ) );
     }
 
     @Test
@@ -217,25 +218,25 @@ public class TestRequireFileChecksum
         throws IOException, EnforcerRuleException
     {
         String configuredMessage = "testMessage";
-        Throwable exception = assertThrows(EnforcerRuleException.class, () -> {
-            File f = File.createTempFile("junit", null, temporaryFolder);
-            FileUtils.fileWrite(f, "message");
+        Throwable exception = assertThrows( EnforcerRuleException.class, () -> {
+            File f = File.createTempFile( "junit", null, temporaryFolder );
+            FileUtils.fileWrite( f, "message" );
 
-            rule.setFile(f);
-            rule.setChecksum("ffeeddccbbaa99887766554433221100");
-            rule.setType("md5");
-            rule.setMessage(configuredMessage);
+            rule.setFile( f );
+            rule.setChecksum( "ffeeddccbbaa99887766554433221100" );
+            rule.setType( "md5" );
+            rule.setMessage( configuredMessage );
 
-            rule.execute(EnforcerTestUtils.getHelper());
-        });
-        assertTrue(exception.getMessage().contains(configuredMessage));
+            rule.execute( EnforcerTestUtils.getHelper() );
+        } );
+        assertTrue( exception.getMessage().contains( configuredMessage ) );
     }
 
     @Test
     public void testFileChecksumSha1()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -249,7 +250,7 @@ public class TestRequireFileChecksum
     public void testFileChecksumSha256()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -263,7 +264,7 @@ public class TestRequireFileChecksum
     public void testFileChecksumSha384()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -277,7 +278,7 @@ public class TestRequireFileChecksum
     public void testFileChecksumSha512()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "message" );
 
         rule.setFile( f );
@@ -287,11 +288,14 @@ public class TestRequireFileChecksum
         rule.execute( EnforcerTestUtils.getHelper() );
     }
 
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
+    private static File newFolder( File root, String... subDirs )
+        throws IOException
+    {
+        String subFolder = String.join( "/", subDirs );
+        File result = new File( root, subFolder );
+        if ( !result.mkdirs() )
+        {
+            throw new IOException( "Couldn't create folders " + root );
         }
         return result;
     }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesDontExist.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesDontExist.java
@@ -37,14 +37,14 @@ public class TestRequireFilesDontExist
 {
     @TempDir
     public File temporaryFolder;
-    
+
     private RequireFilesDontExist rule = new RequireFilesDontExist();
 
     @Test
     public void testFileExists()
         throws EnforcerRuleException, IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
 
         rule.setFiles( new File[] { f } );
 
@@ -130,7 +130,7 @@ public class TestRequireFilesDontExist
     public void testFileDoesNotExist()
         throws EnforcerRuleException, IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         f.delete();
 
         assertFalse( f.exists() );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesDontExist.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesDontExist.java
@@ -19,18 +19,14 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test the "require files don't exist" rule.
@@ -39,8 +35,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class TestRequireFilesDontExist
 {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
     
     private RequireFilesDontExist rule = new RequireFilesDontExist();
 
@@ -48,7 +44,7 @@ public class TestRequireFilesDontExist
     public void testFileExists()
         throws EnforcerRuleException, IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
 
         rule.setFiles( new File[] { f } );
 
@@ -134,7 +130,7 @@ public class TestRequireFilesDontExist
     public void testFileDoesNotExist()
         throws EnforcerRuleException, IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         f.delete();
 
         assertFalse( f.exists() );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesExist.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesExist.java
@@ -19,17 +19,13 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test the "require files exist" rule.
@@ -38,8 +34,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class TestRequireFilesExist
 {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
     
     private RequireFilesExist rule = new RequireFilesExist();
 
@@ -47,7 +43,7 @@ public class TestRequireFilesExist
     public void testFileExists()
         throws Exception
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
 
         rule.setFiles( new File[] { f.getCanonicalFile() } );
 
@@ -116,7 +112,7 @@ public class TestRequireFilesExist
     public void testFileDoesNotExist()
         throws Exception
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         f.delete();
 
         assertFalse( f.exists() );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesExist.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesExist.java
@@ -36,20 +36,20 @@ public class TestRequireFilesExist
 {
     @TempDir
     public File temporaryFolder;
-    
+
     private RequireFilesExist rule = new RequireFilesExist();
 
     @Test
     public void testFileExists()
         throws Exception
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
 
         rule.setFiles( new File[] { f.getCanonicalFile() } );
 
         rule.execute( EnforcerTestUtils.getHelper() );
     }
-    
+
     @Test
     public void testFileOsIndependentExists()
         throws Exception
@@ -61,7 +61,6 @@ public class TestRequireFilesExist
 
         assertNotNull( e.getMessage() );
     }
-
 
     @Test
     public void testEmptyFile()
@@ -112,7 +111,7 @@ public class TestRequireFilesExist
     public void testFileDoesNotExist()
         throws Exception
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         f.delete();
 
         assertFalse( f.exists() );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesSize.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesSize.java
@@ -19,12 +19,7 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -34,9 +29,8 @@ import java.io.IOException;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test the "require files exist" rule.
@@ -45,8 +39,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class TestRequireFilesSize
 {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     private RequireFilesSize rule = new RequireFilesSize();
 
@@ -54,7 +48,7 @@ public class TestRequireFilesSize
     public void testFileExists()
         throws EnforcerRuleException, IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
 
         rule.setFiles( new File[] { f } );
 
@@ -95,7 +89,7 @@ public class TestRequireFilesSize
         assertEquals( 0, rule.getFiles().length );
 
         MockProject project = new MockProject();
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
 
         ArtifactStubFactory factory = new ArtifactStubFactory();
         Artifact a = factory.getReleaseArtifact();
@@ -114,7 +108,7 @@ public class TestRequireFilesSize
     public void testFileDoesNotExist()
         throws EnforcerRuleException, IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         f.delete();
         assertFalse( f.exists() );
         rule.setFiles( new File[] { f } );
@@ -134,7 +128,7 @@ public class TestRequireFilesSize
     public void testFileTooSmall()
         throws EnforcerRuleException, IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         rule.setFiles( new File[] { f } );
         rule.setMinsize( 10 );
         try
@@ -152,7 +146,7 @@ public class TestRequireFilesSize
     public void testFileTooBig()
         throws IOException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         try ( BufferedWriter out = new BufferedWriter( new FileWriter( f ) ) )
         {            
             out.write( "123456789101112131415" );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesSize.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireFilesSize.java
@@ -48,7 +48,7 @@ public class TestRequireFilesSize
     public void testFileExists()
         throws EnforcerRuleException, IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
 
         rule.setFiles( new File[] { f } );
 
@@ -89,7 +89,7 @@ public class TestRequireFilesSize
         assertEquals( 0, rule.getFiles().length );
 
         MockProject project = new MockProject();
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
 
         ArtifactStubFactory factory = new ArtifactStubFactory();
         Artifact a = factory.getReleaseArtifact();
@@ -108,7 +108,7 @@ public class TestRequireFilesSize
     public void testFileDoesNotExist()
         throws EnforcerRuleException, IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         f.delete();
         assertFalse( f.exists() );
         rule.setFiles( new File[] { f } );
@@ -128,7 +128,7 @@ public class TestRequireFilesSize
     public void testFileTooSmall()
         throws EnforcerRuleException, IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         rule.setFiles( new File[] { f } );
         rule.setMinsize( 10 );
         try
@@ -146,9 +146,9 @@ public class TestRequireFilesSize
     public void testFileTooBig()
         throws IOException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         try ( BufferedWriter out = new BufferedWriter( new FileWriter( f ) ) )
-        {            
+        {
             out.write( "123456789101112131415" );
         }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVendor.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVendor.java
@@ -22,10 +22,10 @@ package org.apache.maven.plugins.enforcer;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -43,7 +43,7 @@ public class TestRequireJavaVendor
 
     private RequireJavaVendor underTest;
 
-    @Before
+    @BeforeEach
     public void prepareTest()
     {
         underTest = new RequireJavaVendor();

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
@@ -62,7 +62,7 @@ public class TestRequireJavaVersion
         assertThat( RequireJavaVersion.normalizeJDKVersion( "1.6.0-dp2" ) ).isEqualTo( "1.6.0-2" );
         assertThat( RequireJavaVersion.normalizeJDKVersion( "1.8.0_73" ) ).isEqualTo( "1.8.0-73" );
         assertThat( RequireJavaVersion.normalizeJDKVersion( "9" ) ).isEqualTo( "9" );
-        
+
         assertThat( RequireJavaVersion.normalizeJDKVersion( "17" ) ).isEqualTo( "17" );
 
     }
@@ -92,17 +92,17 @@ public class TestRequireJavaVersion
     public void excludingTheCurrentJavaVersionViaRangeThisShouldFailWithException()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
-            String thisVersion = RequireJavaVersion.normalizeJDKVersion(SystemUtils.JAVA_VERSION);
+        assertThrows( EnforcerRuleException.class, () -> {
+            String thisVersion = RequireJavaVersion.normalizeJDKVersion( SystemUtils.JAVA_VERSION );
 
             RequireJavaVersion rule = new RequireJavaVersion();
             // exclude this version
-            rule.setVersion("(" + thisVersion);
+            rule.setVersion( "(" + thisVersion );
 
             EnforcerRuleHelper helper = EnforcerTestUtils.getHelper();
-            rule.execute(helper);
+            rule.execute( helper );
             // intentionally no assertThat(...) because we expect and exception.
-        });
+        } );
         // intentionally no assertThat(...) because we expect and exception.
     }
 

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireJavaVersion.java
@@ -20,12 +20,13 @@ package org.apache.maven.plugins.enforcer;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestRequireJavaVersion.
@@ -87,23 +88,26 @@ public class TestRequireJavaVersion
         // intentionally no assertThat(...) because we don't expect and exception.
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void excludingTheCurrentJavaVersionViaRangeThisShouldFailWithException()
         throws EnforcerRuleException
     {
-        String thisVersion = RequireJavaVersion.normalizeJDKVersion( SystemUtils.JAVA_VERSION );
+        assertThrows(EnforcerRuleException.class, () -> {
+            String thisVersion = RequireJavaVersion.normalizeJDKVersion(SystemUtils.JAVA_VERSION);
 
-        RequireJavaVersion rule = new RequireJavaVersion();
-        // exclude this version
-        rule.setVersion( "(" + thisVersion );
+            RequireJavaVersion rule = new RequireJavaVersion();
+            // exclude this version
+            rule.setVersion("(" + thisVersion);
 
-        EnforcerRuleHelper helper = EnforcerTestUtils.getHelper();
-        rule.execute( helper );
+            EnforcerRuleHelper helper = EnforcerTestUtils.getHelper();
+            rule.execute(helper);
+            // intentionally no assertThat(...) because we expect and exception.
+        });
         // intentionally no assertThat(...) because we expect and exception.
     }
 
     @Test
-    @Ignore
+    @Disabled
     // TODO: Think about the intention of this test? What should it prove?
     public void thisShouldNotCrash()
         throws EnforcerRuleException

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireNoRepositories.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireNoRepositories.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
@@ -37,8 +39,8 @@ import org.apache.maven.model.RepositoryPolicy;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the "require no repositories" rule.
@@ -54,7 +56,7 @@ public class TestRequireNoRepositories
 
     private MavenSession session;
 
-    @Before
+    @BeforeEach
     public void before()
         throws ExpressionEvaluationException
     {
@@ -193,29 +195,33 @@ public class TestRequireNoRepositories
     /**
      * The model contains a single repository which is is not allowed by the default rules.
      */
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testAllBannedWithRepository()
         throws EnforcerRuleException
     {
-        MavenProject baseProject = createStandAloneProject();
-        addRepository( baseProject, createRepository( "repo", "http://example.com/repo" ) );
-        setupSortedProjects( Collections.singletonList( baseProject ) );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject baseProject = createStandAloneProject();
+            addRepository(baseProject, createRepository("repo", "http://example.com/repo"));
+            setupSortedProjects(Collections.singletonList(baseProject));
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
     /**
      * The model contains a single plugin repository which is is not allowed by the default rules.
      */
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testAllBannedWithPluginRepository()
         throws EnforcerRuleException
     {
-        MavenProject baseProject = createStandAloneProject();
-        addPluginRepository( baseProject, createRepository( "repo", "http://example.com/repo" ) );
-        setupSortedProjects( Collections.singletonList( baseProject ) );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject baseProject = createStandAloneProject();
+            addPluginRepository(baseProject, createRepository("repo", "http://example.com/repo"));
+            setupSortedProjects(Collections.singletonList(baseProject));
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
     /**
@@ -319,15 +325,17 @@ public class TestRequireNoRepositories
         rule.execute( helper );
     }
 
-    @Test( expected = EnforcerRuleException.class )
+    @Test
     public void testAllBannedWithSnapshotRepository()
         throws EnforcerRuleException
     {
-        MavenProject baseProject = createStandAloneProject();
-        addRepository( baseProject, createSnapshotRepository( "repo", "http://example.com/repo" ) );
-        setupSortedProjects( Collections.singletonList( baseProject ) );
+        assertThrows(EnforcerRuleException.class, () -> {
+            MavenProject baseProject = createStandAloneProject();
+            addRepository(baseProject, createSnapshotRepository("repo", "http://example.com/repo"));
+            setupSortedProjects(Collections.singletonList(baseProject));
 
-        rule.execute( helper );
+            rule.execute(helper);
+        });
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireNoRepositories.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireNoRepositories.java
@@ -199,13 +199,13 @@ public class TestRequireNoRepositories
     public void testAllBannedWithRepository()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject baseProject = createStandAloneProject();
-            addRepository(baseProject, createRepository("repo", "http://example.com/repo"));
-            setupSortedProjects(Collections.singletonList(baseProject));
+            addRepository( baseProject, createRepository( "repo", "http://example.com/repo" ) );
+            setupSortedProjects( Collections.singletonList( baseProject ) );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     /**
@@ -215,13 +215,13 @@ public class TestRequireNoRepositories
     public void testAllBannedWithPluginRepository()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject baseProject = createStandAloneProject();
-            addPluginRepository(baseProject, createRepository("repo", "http://example.com/repo"));
-            setupSortedProjects(Collections.singletonList(baseProject));
+            addPluginRepository( baseProject, createRepository( "repo", "http://example.com/repo" ) );
+            setupSortedProjects( Collections.singletonList( baseProject ) );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     /**
@@ -329,13 +329,13 @@ public class TestRequireNoRepositories
     public void testAllBannedWithSnapshotRepository()
         throws EnforcerRuleException
     {
-        assertThrows(EnforcerRuleException.class, () -> {
+        assertThrows( EnforcerRuleException.class, () -> {
             MavenProject baseProject = createStandAloneProject();
-            addRepository(baseProject, createSnapshotRepository("repo", "http://example.com/repo"));
-            setupSortedProjects(Collections.singletonList(baseProject));
+            addRepository( baseProject, createSnapshotRepository( "repo", "http://example.com/repo" ) );
+            setupSortedProjects( Collections.singletonList( baseProject ) );
 
-            rule.execute(helper);
-        });
+            rule.execute( helper );
+        } );
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireOS.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireOS.java
@@ -50,7 +50,7 @@ public class TestRequireOS
         Log log = new SystemStreamLog();
 
         RequireOS rule = new RequireOS( new OperatingSystemProfileActivator() );
-        
+
         rule.displayOSInfo( log, true );
 
         Iterator<String> iter = Os.getValidFamilies().iterator();
@@ -111,15 +111,16 @@ public class TestRequireOS
         rule.setVersion( "!somecrazyversion" );
         assertTrue( rule.isAllowed() );
     }
-    
+
     @Test
-    public void testInvalidFamily() throws Exception
+    public void testInvalidFamily()
+        throws Exception
     {
         RequireOS rule = new RequireOS();
-        
+
         EnforcerRuleHelper helper = EnforcerTestUtils.getHelper();
         helper.getContainer().addComponent( new OperatingSystemProfileActivator(), "os" );
-        
+
         rule.setFamily( "junk" );
         try
         {
@@ -129,7 +130,7 @@ public class TestRequireOS
         catch ( EnforcerRuleException e )
         {
             assertThat( e.getMessage(), startsWith( "Invalid Family type used. Valid family types are: " ) );
-        } 
+        }
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireOS.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireOS.java
@@ -21,9 +21,7 @@ package org.apache.maven.plugins.enforcer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Iterator;
 
@@ -33,7 +31,7 @@ import org.apache.maven.model.profile.activation.OperatingSystemProfileActivator
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.codehaus.plexus.util.Os;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Exhaustively check the OS mojo.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugins.enforcer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -75,14 +74,12 @@ public class TestRequirePluginVersions
         plugins.add( EnforcerTestUtils.newPlugin( "group", "f-artifact", "1.0-SNAPSHOT" ) );
         plugins.add( EnforcerTestUtils.newPlugin( "group", "g-artifact", "1.0-12345678.123456-1" ) );
 
-
         List<PluginWrapper> pluginWrappers = PluginWrapper.addAll( plugins, false );
 
         RequirePluginVersions rule = new RequirePluginVersions();
         rule.setBanLatest( false );
         rule.setBanRelease( false );
         rule.setBanSnapshots( false );
-
 
         EnforcerRuleHelper helper = EnforcerTestUtils.getHelper();
 
@@ -307,17 +304,16 @@ public class TestRequirePluginVersions
     {
         RequirePluginVersions rule = new RequirePluginVersions();
 
-        Set <Plugin> plugins = new HashSet<Plugin>();
+        Set<Plugin> plugins = new HashSet<Plugin>();
         plugins.add( EnforcerTestUtils.newPlugin( "group", "a-artifact", "1.0" ) );
         plugins.add( EnforcerTestUtils.newPlugin( "group", "foo", null ) );
         plugins.add( EnforcerTestUtils.newPlugin( "group", "foo2", "" ) );
 
         List<String> unchecked = new ArrayList<String>();
-        //intentionally inserting spaces to make sure they are handled correctly.
+        // intentionally inserting spaces to make sure they are handled correctly.
         unchecked.add( "group : a-artifact" );
 
         Collection<Plugin> results = rule.removeUncheckedPlugins( unchecked, plugins );
-
 
         // make sure only one new plugin has been added
         assertNotNull( results );
@@ -346,11 +342,11 @@ public class TestRequirePluginVersions
         // make sure only one new plugin has been added
         assertNotNull( results );
         assertEquals( 5, results.size() );
-        assertTrue( results.contains( "group:foo") );
-        assertTrue( results.contains( "group:foo2") );
-        assertTrue( results.contains( "group:a-artifact") );
-        assertTrue( results.contains( "group2:a") );
-        assertTrue( results.contains( "group3:b") );
+        assertTrue( results.contains( "group:foo" ) );
+        assertTrue( results.contains( "group:foo2" ) );
+        assertTrue( results.contains( "group:a-artifact" ) );
+        assertTrue( results.contains( "group2:a" ) );
+        assertTrue( results.contains( "group3:b" ) );
     }
 
     /**
@@ -364,12 +360,11 @@ public class TestRequirePluginVersions
         Set<String> plugins = new HashSet<String>();
         Collection<String> results = rule.combineUncheckedPlugins( plugins, "group2:a,group3:b" );
 
-
         // make sure only one new plugin has been added
         assertNotNull( results );
         assertEquals( 2, results.size() );
-        assertTrue( results.contains( "group2:a") );
-        assertTrue( results.contains( "group3:b") );
+        assertTrue( results.contains( "group2:a" ) );
+        assertTrue( results.contains( "group3:b" ) );
     }
 
     /**
@@ -382,12 +377,11 @@ public class TestRequirePluginVersions
 
         Collection<String> results = rule.combineUncheckedPlugins( null, "group2:a,group3:b" );
 
-
         // make sure only one new plugin has been added
         assertNotNull( results );
         assertEquals( 2, results.size() );
-        assertTrue( results.contains( "group2:a") );
-        assertTrue( results.contains( "group3:b") );
+        assertTrue( results.contains( "group2:a" ) );
+        assertTrue( results.contains( "group3:b" ) );
     }
 
     /**
@@ -406,9 +400,9 @@ public class TestRequirePluginVersions
         Collection<String> results = rule.combineUncheckedPlugins( plugins, "" );
         assertNotNull( results );
         assertEquals( 3, results.size() );
-        assertTrue( results.contains( "group:foo") );
-        assertTrue( results.contains( "group:foo2") );
-        assertTrue( results.contains( "group:a-artifact") );
+        assertTrue( results.contains( "group:foo" ) );
+        assertTrue( results.contains( "group:foo2" ) );
+        assertTrue( results.contains( "group:a-artifact" ) );
     }
 
     /**
@@ -427,9 +421,9 @@ public class TestRequirePluginVersions
         Collection<String> results = rule.combineUncheckedPlugins( plugins, null );
         assertNotNull( results );
         assertEquals( 3, results.size() );
-        assertTrue( results.contains( "group:foo") );
-        assertTrue( results.contains( "group:foo2") );
-        assertTrue( results.contains( "group:a-artifact") );
+        assertTrue( results.contains( "group:foo" ) );
+        assertTrue( results.contains( "group:foo2" ) );
+        assertTrue( results.contains( "group:a-artifact" ) );
     }
 
     /**
@@ -448,12 +442,11 @@ public class TestRequirePluginVersions
         Collection<String> results = rule.combineUncheckedPlugins( plugins, "a" );
         assertNotNull( results );
         assertEquals( 4, results.size() );
-        assertTrue( results.contains( "group:foo") );
-        assertTrue( results.contains( "group:foo2") );
-        //this should be here, the checking of a valid plugin string happens in another method.
-        assertTrue( results.contains( "a") );
+        assertTrue( results.contains( "group:foo" ) );
+        assertTrue( results.contains( "group:foo2" ) );
+        // this should be here, the checking of a valid plugin string happens in another method.
+        assertTrue( results.contains( "a" ) );
     }
-
 
     /**
      * Assert contains plugin.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequirePluginVersions.java
@@ -19,11 +19,7 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 import java.util.ArrayList;
@@ -36,7 +32,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.enforcer.utils.PluginWrapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestRequirePluginVersions.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireProperty.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireProperty.java
@@ -19,11 +19,11 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestRequireProperty.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
@@ -28,7 +28,7 @@ import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.plugins.enforcer.utils.EnforcerRuleUtilsHelper;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestNoSnapshots.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseDeps.java
@@ -80,7 +80,7 @@ public class TestRequireReleaseDeps
         project.setParent( parent );
         project.setArtifacts( null );
         project.setDependencyArtifacts( null );
-        helper = EnforcerTestUtils.getHelper(project);
+        helper = EnforcerTestUtils.getHelper( project );
 
         rule.setFailWhenParentIsSnapshot( true );
         EnforcerRuleUtilsHelper.execute( rule, helper, true );
@@ -88,21 +88,23 @@ public class TestRequireReleaseDeps
         rule.setFailWhenParentIsSnapshot( false );
         EnforcerRuleUtilsHelper.execute( rule, helper, false );
     }
-    
+
     @Test
-    public void testWildcardIgnore() throws Exception
+    public void testWildcardIgnore()
+        throws Exception
     {
         RequireReleaseDeps rule = newRequireReleaseDeps();
         rule.setExcludes( Collections.singletonList( "*:*:*:*:test" ) );
         rule.setOnlyWhenRelease( true );
         rule.setSearchTransitive( false );
-        
+
         ArtifactStubFactory factory = new ArtifactStubFactory();
         MockProject project = new MockProject();
         project.setArtifact( factory.getReleaseArtifact() );
-        project.setDependencyArtifacts( Collections.singleton( factory.createArtifact( "g", "a", "1.0-SNAPSHOT", "test" ) ) );
+        project.setDependencyArtifacts( Collections.singleton( factory.createArtifact( "g", "a", "1.0-SNAPSHOT",
+                                                                                       "test" ) ) );
         EnforcerRuleHelper helper = EnforcerTestUtils.getHelper( project );
-        
+
         EnforcerRuleUtilsHelper.execute( rule, helper, false );
     }
 
@@ -115,22 +117,22 @@ public class TestRequireReleaseDeps
         RequireReleaseDeps rule = newRequireReleaseDeps();
         rule.getCacheId();
     }
-    
+
     private RequireReleaseDeps newRequireReleaseDeps()
     {
         RequireReleaseDeps rule = new RequireReleaseDeps()
         {
-            
+
             @Override
             protected Set<Artifact> getDependenciesToCheck( ProjectBuildingRequest buildingRequest )
             {
                 MavenProject project = buildingRequest.getProject();
 
                 // the integration with dependencyGraphTree is verified with the integration tests
-                // for unit-testing 
+                // for unit-testing
                 return isSearchTransitive() ? project.getArtifacts() : project.getDependencyArtifacts();
             }
-        };        
+        };
         return rule;
     }
 }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseVersion.java
@@ -66,7 +66,7 @@ public class TestRequireReleaseVersion
         MockProject parent = new MockProject();
         parent.setArtifact( factory.getSnapshotArtifact() );
         project.setParent( parent );
-        helper = EnforcerTestUtils.getHelper(project);
+        helper = EnforcerTestUtils.getHelper( project );
 
         ( (RequireReleaseVersion) rule ).setFailWhenParentIsSnapshot( true );
         EnforcerRuleUtilsHelper.execute( rule, helper, true );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireReleaseVersion.java
@@ -19,8 +19,8 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 
@@ -28,7 +28,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.plugins.enforcer.utils.EnforcerRuleUtilsHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class TestRequireReleaseVersion.

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireSnapshotVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireSnapshotVersion.java
@@ -23,8 +23,8 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.plugins.enforcer.utils.EnforcerRuleUtilsHelper;
 import org.apache.maven.project.MavenProject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -42,7 +42,7 @@ public class TestRequireSnapshotVersion
 
     private RequireSnapshotVersion rule;
 
-    @Before
+    @BeforeEach
     public void before()
     {
         project = new MockProject();

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireTextFileChecksum.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireTextFileChecksum.java
@@ -27,10 +27,9 @@ import java.nio.charset.StandardCharsets;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.plugins.enforcer.utils.NormalizeLineSeparatorReader.LineSeparator;
 import org.codehaus.plexus.util.FileUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test the "RequireTextFileChecksum" rule
@@ -41,14 +40,14 @@ public class TestRequireTextFileChecksum
 
     private RequireTextFileChecksum rule = new RequireTextFileChecksum();
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Test
     public void testFileChecksumMd5NormalizedFromUnixToWindows()
         throws IOException, EnforcerRuleException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );
@@ -64,7 +63,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromWindowsToWindows()
         throws IOException, EnforcerRuleException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         FileUtils.fileWrite( f, "line1\r\nline2\r\n" );
 
         rule.setFile( f );
@@ -80,7 +79,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromWindowsToUnix()
         throws IOException, EnforcerRuleException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         FileUtils.fileWrite( f, "line1\r\nline2\r\n" );
 
         rule.setFile( f );
@@ -96,7 +95,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromUnixToUnix()
         throws IOException, EnforcerRuleException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );
@@ -112,7 +111,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedWithMissingFileCharsetParameter()
         throws IOException, EnforcerRuleException
     {
-        File f = temporaryFolder.newFile();
+        File f = File.createTempFile("junit", null, temporaryFolder);
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );
@@ -122,7 +121,7 @@ public class TestRequireTextFileChecksum
 
         rule.execute( EnforcerTestUtils.getHelper() );
         // name is not unique therefore compare generated charset
-        Assert.assertEquals( Charset.forName( System.getProperty( "file.encoding" ) ), rule.encoding );
+        Assertions.assertEquals( Charset.forName( System.getProperty( "file.encoding" ) ), rule.encoding );
     }
 
 }

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireTextFileChecksum.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/TestRequireTextFileChecksum.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test the "RequireTextFileChecksum" rule
- *
  */
 public class TestRequireTextFileChecksum
 {
@@ -47,7 +46,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromUnixToWindows()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );
@@ -63,7 +62,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromWindowsToWindows()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "line1\r\nline2\r\n" );
 
         rule.setFile( f );
@@ -79,7 +78,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromWindowsToUnix()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "line1\r\nline2\r\n" );
 
         rule.setFile( f );
@@ -95,7 +94,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedFromUnixToUnix()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );
@@ -111,7 +110,7 @@ public class TestRequireTextFileChecksum
     public void testFileChecksumMd5NormalizedWithMissingFileCharsetParameter()
         throws IOException, EnforcerRuleException
     {
-        File f = File.createTempFile("junit", null, temporaryFolder);
+        File f = File.createTempFile( "junit", null, temporaryFolder );
         FileUtils.fileWrite( f, "line1\nline2\n" );
 
         rule.setFile( f );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtilsHelper.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtilsHelper.java
@@ -1,6 +1,6 @@
 package org.apache.maven.plugins.enforcer.utils;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/MockEnforcerExpressionEvaluator.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/MockEnforcerExpressionEvaluator.java
@@ -41,7 +41,7 @@ public class MockEnforcerExpressionEvaluator
         super( theContext, new MojoExecution( new MojoDescriptor() ) );
     }
 
-    @Override 
+    @Override
     public Object evaluate( String expr )
         throws ExpressionEvaluationException
     {

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
@@ -19,7 +19,6 @@ package org.apache.maven.plugins.enforcer.utils;
  * under the License.
  */
 
-import junit.framework.TestCase;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
@@ -27,18 +26,24 @@ import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher.Pattern;
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class TestArtifactMatcher extends TestCase
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestArtifactMatcher
 {
 	private ArtifactMatcher matcher;
 	
 	Collection<String> patterns = new ArrayList<String>();
 	
 	Collection<String> ignorePatterns = new ArrayList<String>();
-	
-	public void testPatternInvalidInput() throws InvalidVersionSpecificationException
+
+    @Test
+    public void testPatternInvalidInput() throws InvalidVersionSpecificationException
 	{
 		try
 		{
@@ -70,7 +75,8 @@ public class TestArtifactMatcher extends TestCase
 		catch(NullPointerException e){}
 	}
 
-	public void testPattern() throws InvalidVersionSpecificationException
+    @Test
+    public void testPattern() throws InvalidVersionSpecificationException
 	{
 		executePatternMatch("groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "compile", "jar", true);
 		
@@ -100,8 +106,9 @@ public class TestArtifactMatcher extends TestCase
         
         executePatternMatch("org.apache.*:maven-*:*", "org.apache.maven", "maven-core", "3.0", "", "", true);
 	}
-	
-	public void testMatch() throws InvalidVersionSpecificationException
+
+    @Test
+    public void testMatch() throws InvalidVersionSpecificationException
 	{
 		patterns.add("groupId:artifactId:1.0");
 		patterns.add("*:anotherArtifact");

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestArtifactMatcher.java
@@ -36,99 +36,111 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestArtifactMatcher
 {
-	private ArtifactMatcher matcher;
-	
-	Collection<String> patterns = new ArrayList<String>();
-	
-	Collection<String> ignorePatterns = new ArrayList<String>();
+    private ArtifactMatcher matcher;
+
+    Collection<String> patterns = new ArrayList<String>();
+
+    Collection<String> ignorePatterns = new ArrayList<String>();
 
     @Test
-    public void testPatternInvalidInput() throws InvalidVersionSpecificationException
-	{
-		try
-		{
-			new Pattern(null);
-			fail("NullPointerException expected.");
-		}
-		catch(NullPointerException e){}
-		
-		try
-		{
-			new Pattern("a:b:c:d:e:f:g");
-			fail("IllegalArgumentException expected.");
-		}
-		catch(IllegalArgumentException e){}
-		
-		try
-		{
-			new Pattern("a::");
-			fail("IllegalArgumentException expected.");
-		}
-		catch(IllegalArgumentException e){}
-		
-		try
-		{
-			Pattern p = new Pattern("*");
-			p.match(null);
-			fail("NullPointerException expected.");
-		}
-		catch(NullPointerException e){}
-	}
+    public void testPatternInvalidInput()
+        throws InvalidVersionSpecificationException
+    {
+        try
+        {
+            new Pattern( null );
+            fail( "NullPointerException expected." );
+        }
+        catch ( NullPointerException e )
+        {
+        }
+
+        try
+        {
+            new Pattern( "a:b:c:d:e:f:g" );
+            fail( "IllegalArgumentException expected." );
+        }
+        catch ( IllegalArgumentException e )
+        {
+        }
+
+        try
+        {
+            new Pattern( "a::" );
+            fail( "IllegalArgumentException expected." );
+        }
+        catch ( IllegalArgumentException e )
+        {
+        }
+
+        try
+        {
+            Pattern p = new Pattern( "*" );
+            p.match( null );
+            fail( "NullPointerException expected." );
+        }
+        catch ( NullPointerException e )
+        {
+        }
+    }
 
     @Test
-    public void testPattern() throws InvalidVersionSpecificationException
-	{
-		executePatternMatch("groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "compile", "jar", true);
-		
-		executePatternMatch("groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "", "", true);
-		
-		executePatternMatch("groupId:artifactId:1.0", "groupId", "artifactId", "1.0", "", "", true);
-		
-		executePatternMatch("groupId:artifactId:1.0", "groupId", "artifactId", "1.1", "", "", true);
-		
-		executePatternMatch("groupId:artifactId:[1.0]", "groupId", "artifactId", "1.1", "", "", false);
-		
-		executePatternMatch("groupId:*:1.0", "groupId", "artifactId", "1.0", "test", "", true);
-		
-		executePatternMatch("*:*:1.0", "groupId", "artifactId", "1.0", "", "", true);
-		
-		executePatternMatch("*:artifactId:*", "groupId", "artifactId", "1.0", "", "", true);
-		
-		executePatternMatch("*", "groupId", "artifactId", "1.0", "", "", true);
-		
-		// MENFORCER-74/75
-		executePatternMatch("*:*:*:jar:compile:tests", "groupId", "artifactId", "1.0", "", "", "tests", true);
-		
-		// MENFORCER-83
-        executePatternMatch("*upId", "groupId", "artifactId", "1.0", "", "", true);
-        
-        executePatternMatch("gr*pId:?rt?f?ct?d:1.0", "groupId", "artifactId", "1.0", "", "", true);
-        
-        executePatternMatch("org.apache.*:maven-*:*", "org.apache.maven", "maven-core", "3.0", "", "", true);
-	}
+    public void testPattern()
+        throws InvalidVersionSpecificationException
+    {
+        executePatternMatch( "groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "compile", "jar",
+                             true );
+
+        executePatternMatch( "groupId:artifactId:1.0:jar:compile", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "groupId:artifactId:1.0", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "groupId:artifactId:1.0", "groupId", "artifactId", "1.1", "", "", true );
+
+        executePatternMatch( "groupId:artifactId:[1.0]", "groupId", "artifactId", "1.1", "", "", false );
+
+        executePatternMatch( "groupId:*:1.0", "groupId", "artifactId", "1.0", "test", "", true );
+
+        executePatternMatch( "*:*:1.0", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "*:artifactId:*", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "*", "groupId", "artifactId", "1.0", "", "", true );
+
+        // MENFORCER-74/75
+        executePatternMatch( "*:*:*:jar:compile:tests", "groupId", "artifactId", "1.0", "", "", "tests", true );
+
+        // MENFORCER-83
+        executePatternMatch( "*upId", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "gr*pId:?rt?f?ct?d:1.0", "groupId", "artifactId", "1.0", "", "", true );
+
+        executePatternMatch( "org.apache.*:maven-*:*", "org.apache.maven", "maven-core", "3.0", "", "", true );
+    }
 
     @Test
-    public void testMatch() throws InvalidVersionSpecificationException
-	{
-		patterns.add("groupId:artifactId:1.0");
-		patterns.add("*:anotherArtifact");
-		
-		ignorePatterns.add("badGroup:*:*:test");
-		ignorePatterns.add("*:anotherArtifact:1.1");
-		
-		matcher = new ArtifactMatcher(patterns, ignorePatterns);
-		
-		executeMatch(matcher, "groupId", "artifactId", "1.0", "", "", true);	
-		
-		executeMatch(matcher, "groupId", "anotherArtifact", "1.0", "", "", true);	
-		
-		executeMatch(matcher, "badGroup", "artifactId", "1.0", "", "test", false);
-		
-		executeMatch(matcher, "badGroup", "anotherArtifact", "1.0", "", "", true);	
-		
-		executeMatch(matcher, "groupId", "anotherArtifact", "1.1", "", "", false);	
-	}
-	
+    public void testMatch()
+        throws InvalidVersionSpecificationException
+    {
+        patterns.add( "groupId:artifactId:1.0" );
+        patterns.add( "*:anotherArtifact" );
+
+        ignorePatterns.add( "badGroup:*:*:test" );
+        ignorePatterns.add( "*:anotherArtifact:1.1" );
+
+        matcher = new ArtifactMatcher( patterns, ignorePatterns );
+
+        executeMatch( matcher, "groupId", "artifactId", "1.0", "", "", true );
+
+        executeMatch( matcher, "groupId", "anotherArtifact", "1.0", "", "", true );
+
+        executeMatch( matcher, "badGroup", "artifactId", "1.0", "", "test", false );
+
+        executeMatch( matcher, "badGroup", "anotherArtifact", "1.0", "", "", true );
+
+        executeMatch( matcher, "groupId", "anotherArtifact", "1.1", "", "", false );
+    }
+
     private void executePatternMatch( final String pattern, final String groupId, final String artifactId,
                                       final String versionRange, final String scope, final String type,
                                       boolean expectedResult )
@@ -142,11 +154,10 @@ public class TestArtifactMatcher
                                       final String classifier, boolean expectedResult )
         throws InvalidVersionSpecificationException
     {
-        assertEquals( expectedResult, new ArtifactMatcher.Pattern( pattern ).match( createMockArtifact( groupId,
-                                                                                                        artifactId,
-                                                                                                        versionRange,
-                                                                                                        scope, type,
-                                                                                                        classifier ) ) );
+        assertEquals( expectedResult,
+                      new ArtifactMatcher.Pattern( pattern ).match( createMockArtifact( groupId, artifactId,
+                                                                                        versionRange, scope, type,
+                                                                                        classifier ) ) );
     }
 
     private void executeMatch( final ArtifactMatcher matcher, final String groupId, final String artifactId,

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestMockEnforcerExpressionEvaluator.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestMockEnforcerExpressionEvaluator.java
@@ -24,18 +24,21 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * The Class TestMockEnforcerExpressionEvaluator.
  */
 public class TestMockEnforcerExpressionEvaluator
-    extends TestCase
 {
 
     /**
      * Test evaluate.
      */
+    @Test
     public void testEvaluate()
     {
         MavenSession session = EnforcerTestUtils.getMavenSession();

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestMockEnforcerExpressionEvaluator.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestMockEnforcerExpressionEvaluator.java
@@ -43,8 +43,7 @@ public class TestMockEnforcerExpressionEvaluator
     {
         MavenSession session = EnforcerTestUtils.getMavenSession();
 
-        EnforcerExpressionEvaluator ev =
-            new MockEnforcerExpressionEvaluator( session );
+        EnforcerExpressionEvaluator ev = new MockEnforcerExpressionEvaluator( session );
         assertMatch( ev, "SNAPSHOT" );
         assertMatch( ev, "RELEASE" );
         assertMatch( ev, "SNAPSHOT" );

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestNormalizeLineSeparatorReader.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestNormalizeLineSeparatorReader.java
@@ -19,24 +19,25 @@ package org.apache.maven.plugins.enforcer.utils;
  * under the License.
  */
 
-import junit.framework.TestCase;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 
 import org.apache.commons.io.IOUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.maven.plugins.enforcer.utils.NormalizeLineSeparatorReader.LineSeparator;
+import org.junit.jupiter.api.Test;
 
 public class TestNormalizeLineSeparatorReader
-    extends TestCase
 {
     private final static String UNIX_MULTILINE_STRING = "line1\nline2\n\n";
 
     private final static String WINDOWS_MULTILINE_STRING = "line1\r\nline2\r\n\r\n";
 
+    @Test
     public void testUnixToWindows()
-        throws IOException
+            throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( UNIX_MULTILINE_STRING ), LineSeparator.WINDOWS ) )
@@ -45,8 +46,9 @@ public class TestNormalizeLineSeparatorReader
         }
     }
 
+    @Test
     public void testUnixToUnix()
-        throws IOException
+            throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( UNIX_MULTILINE_STRING ), LineSeparator.UNIX ) )
@@ -55,8 +57,9 @@ public class TestNormalizeLineSeparatorReader
         }
     }
 
+    @Test
     public void testWindowsToUnix()
-        throws IOException
+            throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( WINDOWS_MULTILINE_STRING ), LineSeparator.UNIX ) )
@@ -65,8 +68,9 @@ public class TestNormalizeLineSeparatorReader
         }
     }
 
+    @Test
     public void testWindowsToWindows()
-        throws IOException
+            throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( WINDOWS_MULTILINE_STRING ), LineSeparator.WINDOWS ) )

--- a/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestNormalizeLineSeparatorReader.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/plugins/enforcer/utils/TestNormalizeLineSeparatorReader.java
@@ -37,7 +37,7 @@ public class TestNormalizeLineSeparatorReader
 
     @Test
     public void testUnixToWindows()
-            throws IOException
+        throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( UNIX_MULTILINE_STRING ), LineSeparator.WINDOWS ) )
@@ -48,7 +48,7 @@ public class TestNormalizeLineSeparatorReader
 
     @Test
     public void testUnixToUnix()
-            throws IOException
+        throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( UNIX_MULTILINE_STRING ), LineSeparator.UNIX ) )
@@ -59,7 +59,7 @@ public class TestNormalizeLineSeparatorReader
 
     @Test
     public void testWindowsToUnix()
-            throws IOException
+        throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( WINDOWS_MULTILINE_STRING ), LineSeparator.UNIX ) )
@@ -70,7 +70,7 @@ public class TestNormalizeLineSeparatorReader
 
     @Test
     public void testWindowsToWindows()
-            throws IOException
+        throws IOException
     {
         try ( Reader reader =
             new NormalizeLineSeparatorReader( new StringReader( WINDOWS_MULTILINE_STRING ), LineSeparator.WINDOWS ) )

--- a/maven-enforcer-extension/pom.xml
+++ b/maven-enforcer-extension/pom.xml
@@ -58,8 +58,20 @@
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+   <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-enforcer-plugin</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>run-its</id>

--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -84,8 +84,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -94,11 +94,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -94,8 +94,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/MockEnforcerRule.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/MockEnforcerRule.java
@@ -25,20 +25,19 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 
 /**
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
- * 
  */
 public class MockEnforcerRule
     implements EnforcerRule
 {
 
     public boolean failRule = false;
-    
-    public String cacheId="";
-    
+
+    public String cacheId = "";
+
     public boolean isCacheable = false;
-    
+
     public boolean isResultValid = false;
-    
+
     public boolean executed = false;
 
     public MockEnforcerRule( boolean fail )
@@ -50,9 +49,10 @@ public class MockEnforcerRule
     {
         this.failRule = fail;
         this.isCacheable = isCacheable;
-        this.isResultValid= isResultValid;
+        this.isResultValid = isResultValid;
         this.cacheId = cacheId;
     }
+
     public void execute( EnforcerRuleHelper helper )
         throws EnforcerRuleException
     {
@@ -72,8 +72,7 @@ public class MockEnforcerRule
     }
 
     /**
-     * @param theFailRule
-     *            the failRule to set
+     * @param theFailRule the failRule to set
      */
     public void setFailRule( boolean theFailRule )
     {
@@ -83,7 +82,7 @@ public class MockEnforcerRule
     /**
      * @return the isResultValid
      */
-    public boolean isResultValid ()
+    public boolean isResultValid()
     {
         return this.isResultValid;
     }
@@ -91,7 +90,7 @@ public class MockEnforcerRule
     /**
      * @param theIsResultValid the isResultValid to set
      */
-    public void setResultValid ( boolean theIsResultValid )
+    public void setResultValid( boolean theIsResultValid )
     {
         this.isResultValid = theIsResultValid;
     }
@@ -99,7 +98,7 @@ public class MockEnforcerRule
     /**
      * @param theCacheId the cacheId to set
      */
-    public void setCacheId ( String theCacheId )
+    public void setCacheId( String theCacheId )
     {
         this.cacheId = theCacheId;
     }
@@ -107,31 +106,35 @@ public class MockEnforcerRule
     /**
      * @param theIsCacheable the isCacheable to set
      */
-    public void setCacheable ( boolean theIsCacheable )
+    public void setCacheable( boolean theIsCacheable )
     {
         this.isCacheable = theIsCacheable;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.apache.maven.enforcer.rule.api.EnforcerRule#getCacheId()
      */
-    public String getCacheId ()
+    public String getCacheId()
     {
         return cacheId;
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.apache.maven.enforcer.rule.api.EnforcerRule#isCacheable()
      */
-    public boolean isCacheable ()
+    public boolean isCacheable()
     {
         return isCacheable;
     }
 
-    /* (non-Javadoc)
-     * @see org.apache.maven.enforcer.rule.api.EnforcerRule#isResultValid(org.apache.maven.enforcer.rule.api.EnforcerRule)
+    /*
+     * (non-Javadoc)
+     * @see
+     * org.apache.maven.enforcer.rule.api.EnforcerRule#isResultValid(org.apache.maven.enforcer.rule.api.EnforcerRule)
      */
-    public boolean isResultValid ( EnforcerRule theCachedRule )
+    public boolean isResultValid( EnforcerRule theCachedRule )
     {
         return isResultValid;
     }

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestDefaultEnforcementRuleHelper.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestDefaultEnforcementRuleHelper.java
@@ -22,17 +22,19 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
  * under the License.
  */
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
- * 
+ *
  */
 public class TestDefaultEnforcementRuleHelper
-    extends TestCase
 {
+    @Test
     public void testHelper()
-        throws ComponentLookupException, ExpressionEvaluationException
+            throws ComponentLookupException, ExpressionEvaluationException
     {
         DefaultEnforcementRuleHelper helper = (DefaultEnforcementRuleHelper) EnforcerTestUtils.getHelper();
 

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestDefaultEnforcementRuleHelper.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestDefaultEnforcementRuleHelper.java
@@ -28,13 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
- *
  */
 public class TestDefaultEnforcementRuleHelper
 {
     @Test
     public void testHelper()
-            throws ComponentLookupException, ExpressionEvaluationException
+        throws ComponentLookupException, ExpressionEvaluationException
     {
         DefaultEnforcementRuleHelper helper = (DefaultEnforcementRuleHelper) EnforcerTestUtils.getHelper();
 

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -39,8 +39,8 @@ import org.mockito.quality.Strictness;
  * 
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith( MockitoExtension.class )
+@MockitoSettings( strictness = Strictness.LENIENT )
 public class TestEnforceMojo
 {
 
@@ -116,8 +116,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertFalse( rules[1].executed, "Expected this rule not to be executed." );
 
         // check that skip caching works.
         rules[0] = new MockEnforcerRule( false, "", true, true );
@@ -128,8 +128,8 @@ public class TestEnforceMojo
         mojo.ignoreCache = true;
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertTrue( rules[1].executed , "Expected this rule to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertTrue( rules[1].executed, "Expected this rule to be executed." );
 
         mojo.ignoreCache = false;
 
@@ -142,9 +142,9 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertTrue( rules[1].executed , "Expected this rule to be executed.");
-        assertFalse( rules[2].executed , "Expected this rule not to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertTrue( rules[1].executed, "Expected this rule to be executed." );
+        assertFalse( rules[2].executed, "Expected this rule not to be executed." );
 
         // check that future overrides are working
         rules[0] = new MockEnforcerRule( false, "1", true, true );
@@ -155,8 +155,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertTrue( rules[1].executed , "Expected this rule to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertTrue( rules[1].executed, "Expected this rule to be executed." );
 
         // check that future isResultValid is used
         rules[0] = new MockEnforcerRule( false, "1", true, true );
@@ -167,8 +167,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertTrue( rules[1].executed , "Expected this rule to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertTrue( rules[1].executed, "Expected this rule to be executed." );
 
     }
 
@@ -188,8 +188,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( rules[0].executed , "Expected this rule to be executed.");
-        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
+        assertTrue( rules[0].executed, "Expected this rule to be executed." );
+        assertFalse( rules[1].executed, "Expected this rule not to be executed." );
 
     }
 
@@ -208,8 +208,8 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        assertFalse( rules[0].executed , "Expected this rule not to be executed.");
-        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
+        assertFalse( rules[0].executed, "Expected this rule not to be executed." );
+        assertFalse( rules[1].executed, "Expected this rule not to be executed." );
 
     }
 
@@ -238,8 +238,8 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        assertFalse( rules[0].executed , "Expected this rule not to be executed.");
-        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
+        assertFalse( rules[0].executed, "Expected this rule not to be executed." );
+        assertFalse( rules[1].executed, "Expected this rule not to be executed." );
 
     }
 
@@ -262,14 +262,12 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        Mockito.verify( logSpy ).debug(
-                Mockito.anyString() , Mockito.same( ruleException ) );
+        Mockito.verify( logSpy ).debug( Mockito.anyString(), Mockito.same( ruleException ) );
 
-        Mockito.verify( logSpy, Mockito.never() ).warn(
-                Mockito.anyString(), Mockito.any( Throwable.class ) );
+        Mockito.verify( logSpy, Mockito.never() ).warn( Mockito.anyString(), Mockito.any( Throwable.class ) );
 
-        Mockito.verify( logSpy ).warn(
-                Mockito.matches( ".* failed with message:" + System.lineSeparator() + ruleException.getMessage() ) );
+        Mockito.verify( logSpy ).warn( Mockito.matches( ".* failed with message:" + System.lineSeparator()
+            + ruleException.getMessage() ) );
     }
 
     @Test
@@ -292,20 +290,21 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        Mockito.verify( logSpy ).warn(
-                Mockito.contains("failed without a message"), Mockito.same( enforcerRuleException ) );
+        Mockito.verify( logSpy ).warn( Mockito.contains( "failed without a message" ),
+                                       Mockito.same( enforcerRuleException ) );
 
-        Mockito.verify( logSpy ).warn(
-                Mockito.matches( ".* failed with message:" + System.lineSeparator() + "null" ) );
+        Mockito.verify( logSpy ).warn( Mockito.matches( ".* failed with message:" + System.lineSeparator() + "null" ) );
     }
 
-    private void setupBasics( boolean fail ) {
+    private void setupBasics( boolean fail )
+    {
         mojo.setFail( fail );
         mojo.setSession( EnforcerTestUtils.getMavenSession() );
         mojo.setProject( new MockProject() );
     }
 
-    private Log setupLogSpy() {
+    private Log setupLogSpy()
+    {
         Log spy = Mockito.spy( mojo.getLog() );
         mojo.setLog( spy );
         return spy;

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -19,27 +19,28 @@ package org.apache.maven.plugins.enforcer;
  * under the License.
  */
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * Exhaustively check the enforcer mojo.
  * 
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
-@RunWith( MockitoJUnitRunner.Silent.class )
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestEnforceMojo
 {
 
@@ -115,8 +116,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertFalse( "Expected this rule not to be executed.", rules[1].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
 
         // check that skip caching works.
         rules[0] = new MockEnforcerRule( false, "", true, true );
@@ -127,8 +128,8 @@ public class TestEnforceMojo
         mojo.ignoreCache = true;
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertTrue( "Expected this rule to be executed.", rules[1].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertTrue( rules[1].executed , "Expected this rule to be executed.");
 
         mojo.ignoreCache = false;
 
@@ -141,9 +142,9 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertTrue( "Expected this rule to be executed.", rules[1].executed );
-        assertFalse( "Expected this rule not to be executed.", rules[2].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertTrue( rules[1].executed , "Expected this rule to be executed.");
+        assertFalse( rules[2].executed , "Expected this rule not to be executed.");
 
         // check that future overrides are working
         rules[0] = new MockEnforcerRule( false, "1", true, true );
@@ -154,8 +155,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertTrue( "Expected this rule to be executed.", rules[1].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertTrue( rules[1].executed , "Expected this rule to be executed.");
 
         // check that future isResultValid is used
         rules[0] = new MockEnforcerRule( false, "1", true, true );
@@ -166,8 +167,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertTrue( "Expected this rule to be executed.", rules[1].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertTrue( rules[1].executed , "Expected this rule to be executed.");
 
     }
 
@@ -187,8 +188,8 @@ public class TestEnforceMojo
         EnforceMojo.cache.clear();
         mojo.execute();
 
-        assertTrue( "Expected this rule to be executed.", rules[0].executed );
-        assertFalse( "Expected this rule not to be executed.", rules[1].executed );
+        assertTrue( rules[0].executed , "Expected this rule to be executed.");
+        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
 
     }
 
@@ -207,8 +208,8 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        assertFalse( "Expected this rule not to be executed.", rules[0].executed );
-        assertFalse( "Expected this rule not to be executed.", rules[1].executed );
+        assertFalse( rules[0].executed , "Expected this rule not to be executed.");
+        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
 
     }
 
@@ -237,8 +238,8 @@ public class TestEnforceMojo
 
         mojo.execute();
 
-        assertFalse( "Expected this rule not to be executed.", rules[0].executed );
-        assertFalse( "Expected this rule not to be executed.", rules[1].executed );
+        assertFalse( rules[0].executed , "Expected this rule not to be executed.");
+        assertFalse( rules[1].executed , "Expected this rule not to be executed.");
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,12 +128,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.8.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
         <version>5.8.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,10 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>5.8.1</version>
+        <!-- Needed as PlexusTestCase extends junit.framework.TestCase -->
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,13 +122,32 @@
         <version>3.4.1</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.8.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.8.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.8.1</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <version>3.12.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
         <version>3.12.4</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---- 
See https://issues.apache.org/jira/browse/MENFORCER-372

As for approach I mostly just applied [the OpenRewrite JUnit 5 migration](https://docs.openrewrite.org/tutorials/migrate-from-junit-4-to-junit-5), with some manual fixes needed around exception assertions.

Without the `junit-vintage-engine` the tests still fail with a `ClassNotFoundException` on `junit.framework.TestCase`.