### PR TITLE
[enforcer:enforcer fix] enable RequireSameVersions with plugins parameter

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireSameVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/RequireSameVersions.java
@@ -76,8 +76,8 @@ public class RequireSameVersions
 
         // CHECKSTYLE_OFF: LineLength
         versionMembers.putAll( collectVersionMembers( project.getArtifacts(), dependencies, " (dependency)" ) );
-        versionMembers.putAll( collectVersionMembers( project.getPluginArtifacts(), buildPlugins, " (buildPlugin)" ) );
-        versionMembers.putAll( collectVersionMembers( project.getReportArtifacts(), reportPlugins, " (reportPlugin)" ) );
+        versionMembers.putAll( collectVersionMembers( project.getPluginArtifacts(), buildPluginSet, " (buildPlugin)" ) );
+        versionMembers.putAll( collectVersionMembers( project.getReportArtifacts(), reportPluginSet, " (reportPlugin)" ) );
         // CHECKSTYLE_ON: LineLength
 
         if ( versionMembers.size() > 1 )


### PR DESCRIPTION
org.apache.maven.enforcer:enforcer:3.1.1-SNAPSHOT
RequireSameVersions.java did not add [plugins] parameter to [buildPluings] and [reportPlugins]

Copyright [hymanyin] [name of copyright owner]

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.