### PR TITLE
[MENFORCER-398] show rules processed

### DIFF
--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
@@ -187,7 +187,6 @@ public class EnforceMojo
                 // store the current rule for
                 // logging purposes
                 currentRule = rule.getClass().getName();
-                log.debug( "Executing rule: " + currentRule );
                 try
                 {
                     if ( ignoreCache || shouldExecute( rule ) )
@@ -196,6 +195,7 @@ public class EnforceMojo
                         // noinspection SynchronizationOnLocalVariableOrMethodParameter
                         synchronized ( rule )
                         {
+                            log.info( "Executing rule: " + currentRule );
                             rule.execute( helper );
                         }
                     }

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -53,6 +53,8 @@ public class TestEnforceMojo
     {
         setupBasics( false );
 
+        Log logSpy = setupLogSpy();
+
         try
         {
             mojo.execute();
@@ -69,6 +71,8 @@ public class TestEnforceMojo
         mojo.setRules( rules );
 
         mojo.execute();
+
+        Mockito.verify( logSpy, Mockito.times(2) ).info( Mockito.contains("Executing rule: " + MockEnforcerRule.class.getName()) );
 
         try
         {


### PR DESCRIPTION
Hi there,

this fixes [MENFORCER-398](https://issues.apache.org/jira/browse/MENFORCER-398). It is a simple one line change. Turning on DEBUG already logs what rules are processed. Since most people probably run Maven in default settings they won't see the rules processed. Changing the log level from DEBUG to INFO allows everyone to see the rule processed.

This is an up-for-grabs issue. Feedback welcome.

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).



 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

