### PR TITLE
[MENFORCER-397] allow no rules

### DIFF
--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
@@ -98,6 +98,14 @@ public class EnforceMojo
     private boolean failFast = false;
 
     /**
+     * Flag to fail the build if no rules are present
+     *
+     * @since 3.1.1
+     */
+    @Parameter( property = "enforcer.failIfNoRules", defaultValue = "true" )
+    private boolean failIfNoRules = true;
+
+    /**
      * Array of objects that implement the EnforcerRule interface to execute.
      */
     @Parameter( required = false )
@@ -153,9 +161,17 @@ public class EnforceMojo
 
         if ( !havingRules() )
         {
-            // CHECKSTYLE_OFF: LineLength
-            throw new MojoExecutionException( "No rules are configured. Use the skip flag if you want to disable execution." );
-            // CHECKSTYLE_ON: LineLength
+            if ( isFailIfNoRules() )
+            {
+                // CHECKSTYLE_OFF: LineLength
+                throw new MojoExecutionException( "No rules are configured. Use the skip flag if you want to disable execution." );
+                // CHECKSTYLE_ON: LineLength
+            }
+            else
+            {
+                log.warn( "No rules are configured." );
+                return;
+            }
         }
 
         // messages with warn/error flag
@@ -397,6 +413,22 @@ public class EnforceMojo
     public void setSkip( boolean theSkip )
     {
         this.skip = theSkip;
+    }
+
+    /**
+     * @return the failIfNoRules
+     */
+    public boolean isFailIfNoRules()
+    {
+        return this.failIfNoRules;
+    }
+
+    /**
+     * @param thefailIfNoRules the failIfNoRules to set
+     */
+    public void setFailIfNoRules( boolean thefailIfNoRules )
+    {
+        this.failIfNoRules = thefailIfNoRules;
     }
 
     /**

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -300,6 +300,20 @@ public class TestEnforceMojo
         Mockito.verify( logSpy ).warn( Mockito.matches( ".* failed with message:" + System.lineSeparator() + "null" ) );
     }
 
+    @Test
+    public void testFailIfNoTests()
+            throws MojoExecutionException {
+        setupBasics( false );
+        mojo.setFailIfNoRules( false );
+
+        Log logSpy = setupLogSpy();
+
+        mojo.execute();
+
+        Mockito.verify( logSpy ).warn( Mockito.eq( "No rules are configured." ) );
+        Mockito.verifyNoMoreInteractions( logSpy );
+    }
+
     private void setupBasics( boolean fail )
     {
         mojo.setFail( fail );


### PR DESCRIPTION
Hi there,

attached is another `up-for-grabs`. This PR allows no rules by adding a `failIfNoRules` parameter. Settings `failIfNoRules` to false will log a warning "No rules are configured" instead of throwing an exception. Default behaviour is to throw an exception if there are no rules configured. Like people are used to.

A suitable test case has been added.

Feedback is welcome.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

