### PR TITLE
[MENFORCER-435] Replacing maven-compat and maven-dependency-tree usage with Resolver

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -117,6 +117,7 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TODO: Consider removing this in 4.0+ -->
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
@@ -127,7 +128,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- needed for ArtifactCollector and maven-dependency-tree 2.2 -->
+    <!-- TODO: Consider removing this in 4.0+ -->
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/AbstractBanDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/AbstractBanDependencies.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.plugins.enforcer;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -26,14 +25,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
-import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * Abstract Rule for banning dependencies.
@@ -45,51 +37,36 @@ public abstract class AbstractBanDependencies extends AbstractNonCacheableEnforc
     /** Specify if transitive dependencies should be searched (default) or only look at direct dependencies. */
     private boolean searchTransitive = true;
 
-    private transient DependencyGraphBuilder graphBuilder;
-
     @Override
     public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
-        MavenProject project;
-        try {
-            project = (MavenProject) helper.evaluate("${project}");
-        } catch (ExpressionEvaluationException eee) {
-            throw new EnforcerRuleException("Unable to retrieve the MavenProject: ", eee);
-        }
-
         MavenSession session;
         try {
             session = (MavenSession) helper.evaluate("${session}");
-        } catch (ExpressionEvaluationException eee) {
-            throw new EnforcerRuleException("Unable to retrieve the reactor MavenProject: ", eee);
+        } catch (ExpressionEvaluationException e) {
+            throw new EnforcerRuleException("Cannot resolve MavenSession", e);
         }
-
-        try {
-            graphBuilder = helper.getComponent(DependencyGraphBuilder.class);
-        } catch (ComponentLookupException e) {
-            throw new EnforcerRuleException("Unable to lookup DependencyGraphBuilder: ", e);
-        }
-
-        ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-        buildingRequest.setProject(project);
 
         // get the correct list of dependencies
-        Set<Artifact> dependencies = getDependenciesToCheck(helper, buildingRequest);
+        Set<Artifact> dependencyArtifacts = searchTransitive
+                ? ArtifactUtils.getDependencyArtifacts(ArtifactUtils.resolveTransitiveDependencies(helper))
+                : session.getCurrentProject().getDependencyArtifacts();
 
         // look for banned dependencies
-        Set<Artifact> foundExcludes = checkDependencies(dependencies, helper.getLog());
+        Set<Artifact> bannedDependencies = checkDependencies(dependencyArtifacts, helper.getLog());
 
         // if any are found, fail the check but list all of them
-        if (foundExcludes != null && !foundExcludes.isEmpty()) {
+        if (bannedDependencies != null && !bannedDependencies.isEmpty()) {
             String message = getMessage();
 
             StringBuilder buf = new StringBuilder();
             if (message != null) {
-                buf.append(message + System.lineSeparator());
+                buf.append(message).append(System.lineSeparator());
             }
-            for (Artifact artifact : foundExcludes) {
+            for (Artifact artifact : bannedDependencies) {
                 buf.append(getErrorMessage(artifact));
             }
-            message = buf.toString() + "Use 'mvn dependency:tree' to locate the source of the banned dependencies.";
+            message = buf.append("Use 'mvn dependency:tree' to locate the source of the banned dependencies.")
+                    .toString();
 
             throw new EnforcerRuleException(message);
         }
@@ -99,40 +76,11 @@ public abstract class AbstractBanDependencies extends AbstractNonCacheableEnforc
         return "Found Banned Dependency: " + artifact.getId() + System.lineSeparator();
     }
 
-    private Set<Artifact> getDependenciesToCheck(EnforcerRuleHelper helper, ProjectBuildingRequest buildingRequest) {
-        String cacheKey = buildingRequest.getProject().getId() + "_" + searchTransitive;
-
-        // check in the cache
-        Set<Artifact> dependencies =
-                (Set<Artifact>) helper.getCache(cacheKey, () -> getDependenciesToCheck(buildingRequest));
-
-        return dependencies;
-    }
-
-    protected Set<Artifact> getDependenciesToCheck(ProjectBuildingRequest buildingRequest) {
-        Set<Artifact> dependencies = null;
-        try {
-            DependencyNode node = graphBuilder.buildDependencyGraph(buildingRequest, null);
-            if (searchTransitive) {
-                dependencies = ArtifactUtils.getAllDescendants(node);
-            } else if (node.getChildren() != null) {
-                dependencies = new HashSet<>();
-                for (DependencyNode depNode : node.getChildren()) {
-                    dependencies.add(depNode.getArtifact());
-                }
-            }
-        } catch (DependencyGraphBuilderException e) {
-            // otherwise we need to change the signature of this protected method
-            throw new RuntimeException(e);
-        }
-        return dependencies;
-    }
-
     /**
      * Checks the set of dependencies against the list of excludes.
      *
-     * @param dependencies the dependencies
-     * @param log the log
+     * @param dependencies dependencies to be checked against the list of excludes
+     * @param log          the log
      * @return the sets the
      * @throws EnforcerRuleException the enforcer rule exception
      */

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanDynamicVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BanDynamicVersions.java
@@ -34,6 +34,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher;
+import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.logging.MessageBuilder;
 import org.apache.maven.shared.utils.logging.MessageUtils;
@@ -291,7 +292,7 @@ public class BanDynamicVersions extends AbstractNonCacheableEnforcerRule {
         @Override
         public boolean test(DependencyNode depNode) {
             try {
-                return artifactMatcher.match(RepositoryUtils.toArtifact(depNode.getArtifact()));
+                return artifactMatcher.match(ArtifactUtils.toArtifact(depNode));
             } catch (InvalidVersionSpecificationException e) {
                 throw new IllegalArgumentException("Invalid version found for dependency node " + depNode, e);
             }

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedDependencies.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedDependencies.java
@@ -18,11 +18,7 @@
  */
 package org.apache.maven.plugins.enforcer;
 
-import java.util.List;
-import java.util.Set;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
 
 /**
@@ -30,97 +26,15 @@ import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
  *
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
-public class BannedDependencies extends AbstractBanDependencies {
-
-    /**
-     * Specify the banned dependencies. This can be a list of artifacts in the format
-     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
-     * by using '*' (ie group:*:1.0) <br>
-     * The rule will fail if any dependency matches any exclude, unless it also matches
-     * an include rule.
-     *
-     * @see {@link #setExcludes(List)}
-     * @see {@link #getExcludes()}
-     */
-    private List<String> excludes = null;
-
-    /**
-     * Specify the allowed dependencies. This can be a list of artifacts in the format
-     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
-     * by using '*' (ie group:*:1.0) <br>
-     * Includes override the exclude rules. It is meant to allow wide exclusion rules
-     * with wildcards and still allow a
-     * smaller set of includes. <br>
-     * For example, to ban all xerces except xerces-api -> exclude "xerces", include "xerces:xerces-api"
-     *
-     * @see {@link #setIncludes(List)}
-     * @see {@link #getIncludes()}
-     */
-    private List<String> includes = null;
+public class BannedDependencies extends BannedDependenciesBase {
+    @Override
+    protected boolean validate(Artifact artifact) {
+        return !ArtifactUtils.matchDependencyArtifact(artifact, excludes)
+                || ArtifactUtils.matchDependencyArtifact(artifact, includes);
+    }
 
     @Override
-    protected Set<Artifact> checkDependencies(Set<Artifact> theDependencies, Log log) throws EnforcerRuleException {
-
-        Set<Artifact> excluded = ArtifactUtils.checkDependencies(theDependencies, excludes);
-
-        // anything specifically included should be removed
-        // from the ban list.
-        if (excluded != null) {
-            Set<Artifact> included = ArtifactUtils.checkDependencies(theDependencies, includes);
-
-            if (included != null) {
-                excluded.removeAll(included);
-            }
-        }
-        return excluded;
-    }
-
-    /**
-     * Gets the excludes.
-     *
-     * @return the excludes
-     */
-    public List<String> getExcludes() {
-        return this.excludes;
-    }
-
-    /**
-     * Specify the banned dependencies. This can be a list of artifacts in the format
-     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
-     * by using '*' (ie group:*:1.0) <br>
-     * The rule will fail if any dependency matches any exclude, unless it also matches an
-     * include rule.
-     *
-     * @see #getExcludes()
-     * @param theExcludes the excludes to set
-     */
-    public void setExcludes(List<String> theExcludes) {
-        this.excludes = theExcludes;
-    }
-
-    /**
-     * Gets the includes.
-     *
-     * @return the includes
-     */
-    public List<String> getIncludes() {
-        return this.includes;
-    }
-
-    /**
-     * Specify the allowed dependencies. This can be a list of artifacts in the format
-     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
-     * by using '*' (ie group:*:1.0) <br>
-     * Includes override the exclude rules. It is meant to allow wide exclusion rules with
-     * wildcards and still allow a
-     * smaller set of includes. <br>
-     * For example, to ban all xerces except xerces-api → exclude "xerces",
-     * include "xerces:xerces-api"
-     *
-     * @see #setIncludes(List)
-     * @param theIncludes the includes to set
-     */
-    public void setIncludes(List<String> theIncludes) {
-        this.includes = theIncludes;
+    protected String getErrorMessage() {
+        return "banned via the exclude/include list";
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedDependenciesBase.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/BannedDependenciesBase.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.enforcer;
+
+import com.google.common.base.Strings;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.eclipse.aether.graph.DependencyNode;
+
+/**
+ * Abstract base class for rules which validate the transitive
+ * dependency tree by traversing all children and validating every
+ * dependency artifact.
+ */
+abstract class BannedDependenciesBase extends AbstractNonCacheableEnforcerRule {
+
+    /**
+     * Specify the banned dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     * The rule will fail if any dependency matches any exclude, unless it also matches
+     * an include rule.
+     *
+     * @see #setExcludes(List)
+     * @see #getExcludes()
+     */
+    protected List<String> excludes = null;
+
+    /**
+     * Specify the allowed dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     * Includes override the exclude rules. It is meant to allow wide exclusion rules
+     * with wildcards and still allow a
+     * smaller set of includes. <br>
+     * For example, to ban all xerces except xerces-api -&gt; exclude "xerces", include "xerces:xerces-api"
+     *
+     * @see #setIncludes(List)
+     * @see #getIncludes()
+     */
+    protected List<String> includes = null;
+
+    /** Specify if transitive dependencies should be searched (default) or only look at direct dependencies. */
+    private boolean searchTransitive = true;
+
+    @Override
+    public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        MavenSession session;
+        try {
+            session = (MavenSession) helper.evaluate("${session}");
+        } catch (ExpressionEvaluationException e) {
+            throw new EnforcerRuleException("Cannot resolve MavenSession", e);
+        }
+
+        DependencyNode rootNode = ArtifactUtils.resolveTransitiveDependencies(helper);
+        if (!searchTransitive) {
+            String result = session.getCurrentProject().getDependencyArtifacts().stream()
+                    .filter(a -> !validate(a))
+                    .collect(
+                            StringBuilder::new,
+                            (messageBuilder, node) -> messageBuilder
+                                    .append(node.getId())
+                                    .append(" <--- ")
+                                    .append(getErrorMessage()),
+                            (m1, m2) -> m1.append(m2.toString()))
+                    .toString();
+            if (!result.isEmpty()) {
+                throw new EnforcerRuleException(result);
+            }
+        } else {
+            StringBuilder messageBuilder = new StringBuilder();
+            if (!validate(rootNode, 0, messageBuilder)) {
+                throw new EnforcerRuleException(messageBuilder.toString());
+            }
+        }
+    }
+
+    protected boolean validate(DependencyNode node, int level, StringBuilder messageBuilder) {
+        boolean rootFailed = level > 0 && !validate(ArtifactUtils.toArtifact(node));
+        StringBuilder childMessageBuilder = new StringBuilder();
+        if (rootFailed
+                || !node.getChildren().stream()
+                        .map(childNode -> validate(childNode, level + 1, childMessageBuilder))
+                        .reduce(true, Boolean::logicalAnd)) {
+            messageBuilder
+                    .append(Strings.repeat("   ", level))
+                    .append(ArtifactUtils.toArtifact(node).getId());
+            if (rootFailed) {
+                messageBuilder.append(" <--- ").append(getErrorMessage());
+            }
+            messageBuilder.append(System.lineSeparator()).append(childMessageBuilder);
+            return false;
+        }
+        return true;
+    }
+
+    protected abstract String getErrorMessage();
+
+    /**
+     * Validates a dependency artifact if it fulfills the enforcer rule
+     *
+     * @param dependency dependency to be checked against the list of excludes
+     * @return {@code true} if the dependency <b>passes</b> the rule, {@code false} if the dependency
+     * triggers a validation error
+     */
+    protected abstract boolean validate(Artifact dependency);
+
+    /**
+     * Checks if is search transitive.
+     *
+     * @return the searchTransitive
+     */
+    public boolean isSearchTransitive() {
+        return this.searchTransitive;
+    }
+
+    /**
+     * Sets the search transitive.
+     *
+     * @param theSearchTransitive the searchTransitive to set
+     */
+    public void setSearchTransitive(boolean theSearchTransitive) {
+        this.searchTransitive = theSearchTransitive;
+    }
+
+    /**
+     * Gets the excludes.
+     *
+     * @return the excludes
+     */
+    public List<String> getExcludes() {
+        return this.excludes;
+    }
+
+    /**
+     * Specify the banned dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     * The rule will fail if any dependency matches any exclude, unless it also matches an
+     * include rule.
+     *
+     * @see #getExcludes()
+     * @param theExcludes the excludes to set
+     */
+    public void setExcludes(List<String> theExcludes) {
+        this.excludes = theExcludes;
+    }
+
+    /**
+     * Gets the includes.
+     *
+     * @return the includes
+     */
+    public List<String> getIncludes() {
+        return this.includes;
+    }
+
+    /**
+     * Specify the allowed dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     * Includes override the exclude rules. It is meant to allow wide exclusion rules with
+     * wildcards and still allow a
+     * smaller set of includes. <br>
+     * For example, to ban all xerces except xerces-api → exclude "xerces",
+     * include "xerces:xerces-api"
+     *
+     * @see #setIncludes(List)
+     * @param theIncludes the includes to set
+     */
+    public void setIncludes(List<String> theIncludes) {
+        this.includes = theIncludes;
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/DependencyConvergence.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/DependencyConvergence.java
@@ -18,26 +18,23 @@
  */
 package org.apache.maven.plugins.enforcer;
 
+import static org.apache.maven.artifact.Artifact.SCOPE_PROVIDED;
+import static org.apache.maven.artifact.Artifact.SCOPE_TEST;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.enforcer.utils.ArtifactUtils;
 import org.apache.maven.plugins.enforcer.utils.DependencyVersionMap;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
-import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
-import org.apache.maven.shared.dependency.graph.DependencyNode;
-import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 
 /**
  * @author <a href="mailto:rex@e-hoffman.org">Rex Hoffman</a>
@@ -51,44 +48,10 @@ public class DependencyConvergence implements EnforcerRule {
 
     private List<String> excludes;
 
+    private DependencyVersionMap dependencyVersionMap;
+
     public void setUniqueVersions(boolean uniqueVersions) {
         this.uniqueVersions = uniqueVersions;
-    }
-
-    // CHECKSTYLE_OFF: LineLength
-    /**
-     * Uses the {@link EnforcerRuleHelper} to populate the values of the
-     * {@link DependencyTreeBuilder#buildDependencyTree(MavenProject, ArtifactRepository, ArtifactFactory, ArtifactMetadataSource, ArtifactFilter, ArtifactCollector)}
-     * factory method. <br/>
-     * This method simply exists to hide all the ugly lookup that the {@link EnforcerRuleHelper} has to do.
-     *
-     * @param helper
-     * @return a Dependency Node which is the root of the project's dependency tree
-     * @throws EnforcerRuleException
-     */
-    // CHECKSTYLE_ON: LineLength
-    private DependencyNode getNode(EnforcerRuleHelper helper) throws EnforcerRuleException {
-        try {
-            MavenProject project = (MavenProject) helper.evaluate("${project}");
-            MavenSession session = (MavenSession) helper.evaluate("${session}");
-            DependencyCollectorBuilder dependencyCollectorBuilder =
-                    helper.getComponent(DependencyCollectorBuilder.class);
-            ArtifactRepository repository = (ArtifactRepository) helper.evaluate("${localRepository}");
-
-            ProjectBuildingRequest buildingRequest =
-                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-            buildingRequest.setProject(project);
-            buildingRequest.setLocalRepository(repository);
-            ArtifactFilter filter = (Artifact a) ->
-                    ("compile".equalsIgnoreCase(a.getScope()) || "runtime".equalsIgnoreCase(a.getScope()))
-                            && !a.isOptional();
-
-            return dependencyCollectorBuilder.collectDependencyGraph(buildingRequest, filter);
-        } catch (ExpressionEvaluationException | ComponentLookupException e) {
-            throw new EnforcerRuleException("Unable to lookup a component " + e.getLocalizedMessage(), e);
-        } catch (DependencyCollectorBuilderException e) {
-            throw new EnforcerRuleException("Could not build dependency tree " + e.getLocalizedMessage(), e);
-        }
     }
 
     @Override
@@ -97,12 +60,32 @@ public class DependencyConvergence implements EnforcerRule {
             log = helper.getLog();
         }
         try {
-            DependencyNode node = getNode(helper);
-            DependencyVersionMap visitor = new DependencyVersionMap(log);
-            visitor.setUniqueVersions(uniqueVersions);
-            node.accept(visitor);
-            List<CharSequence> errorMsgs = new ArrayList<>();
-            errorMsgs.addAll(getConvergenceErrorMsgs(visitor.getConflictedVersionNumbers(includes, excludes)));
+            DependencyNode node = ArtifactUtils.resolveTransitiveDependencies(
+                    helper,
+                    // TODO: use a modified version of ExclusionDependencySelector to process excludes and includes
+                    new DependencySelector() {
+                        @Override
+                        public boolean selectDependency(Dependency dependency) {
+                            // regular OptionalDependencySelector only discriminates optional dependencies at level 2+
+                            return !dependency.isOptional()
+                                    // regular scope selectors only discard transitive dependencies
+                                    // and always allow direct dependencies
+                                    && !dependency.getScope().equals(SCOPE_TEST)
+                                    && !dependency.getScope().equals(SCOPE_PROVIDED);
+                        }
+
+                        @Override
+                        public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+                            return this;
+                        }
+                    },
+                    // process dependency exclusions
+                    new ExclusionDependencySelector());
+            dependencyVersionMap = new DependencyVersionMap(log).setUniqueVersions(uniqueVersions);
+            node.accept(dependencyVersionMap);
+
+            List<CharSequence> errorMsgs = new ArrayList<>(
+                    getConvergenceErrorMsgs(dependencyVersionMap.getConflictedVersionNumbers(includes, excludes)));
             for (CharSequence errorMsg : errorMsgs) {
                 log.warn(errorMsg);
             }
@@ -119,8 +102,9 @@ public class DependencyConvergence implements EnforcerRule {
         List<String> loc = new ArrayList<>();
         DependencyNode currentNode = node;
         while (currentNode != null) {
-            loc.add(currentNode.getArtifact().toString());
-            currentNode = currentNode.getParent();
+            // ArtifactUtils.toArtifact(node) adds scope and optional information, if present
+            loc.add(ArtifactUtils.toArtifact(currentNode).toString());
+            currentNode = dependencyVersionMap.getParent(currentNode);
         }
         Collections.reverse(loc);
         StringBuilder builder = new StringBuilder();
@@ -128,8 +112,7 @@ public class DependencyConvergence implements EnforcerRule {
             for (int j = 0; j < i; j++) {
                 builder.append("  ");
             }
-            builder.append("+-" + loc.get(i));
-            builder.append(System.lineSeparator());
+            builder.append("+-").append(loc.get(i)).append(System.lineSeparator());
         }
         return builder;
     }
@@ -144,15 +127,16 @@ public class DependencyConvergence implements EnforcerRule {
 
     private String buildConvergenceErrorMsg(List<DependencyNode> nodeList) {
         StringBuilder builder = new StringBuilder();
-        builder.append(System.lineSeparator() + "Dependency convergence error for "
-                + nodeList.get(0).getArtifact().toString()
-                + " paths to dependency are:" + System.lineSeparator());
+        builder.append(System.lineSeparator())
+                .append("Dependency convergence error for ")
+                .append(nodeList.get(0).getArtifact().toString())
+                .append(" paths to dependency are:")
+                .append(System.lineSeparator());
         if (nodeList.size() > 0) {
             builder.append(buildTreeString(nodeList.get(0)));
         }
         for (DependencyNode node : nodeList.subList(1, nodeList.size())) {
-            builder.append("and" + System.lineSeparator());
-            builder.append(buildTreeString(node));
+            builder.append("and").append(System.lineSeparator()).append(buildTreeString(node));
         }
         return builder.toString();
     }
@@ -168,7 +152,7 @@ public class DependencyConvergence implements EnforcerRule {
     }
 
     @Override
-    public boolean isResultValid(EnforcerRule rule) {
+    public boolean isResultValid(EnforcerRule ignored) {
         return false;
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactUtils.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ArtifactUtils.java
@@ -18,15 +18,34 @@
  */
 package org.apache.maven.plugins.enforcer.utils;
 
+import static java.util.Optional.ofNullable;
+
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.plugins.enforcer.utils.ArtifactMatcher.Pattern;
-import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 
 /**
  *
@@ -34,54 +53,144 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
  * @since 3.0.0
  */
 public final class ArtifactUtils {
-    private ArtifactUtils() {}
 
-    public static Set<Artifact> getAllDescendants(DependencyNode node) {
-        Set<Artifact> children = null;
-        if (node.getChildren() != null) {
-            children = new HashSet<>();
-            for (DependencyNode depNode : node.getChildren()) {
-                children.add(depNode.getArtifact());
-                Set<Artifact> subNodes = getAllDescendants(depNode);
-                if (subNodes != null) {
-                    children.addAll(subNodes);
-                }
-            }
-        }
-        return children;
+    /**
+     * Converts {@link DependencyNode} to {@link Artifact}; in comparison
+     * to {@link RepositoryUtils#toArtifact(org.eclipse.aether.artifact.Artifact)}, this method
+     * assigns {@link Artifact#getScope()} and {@link Artifact#isOptional()} based on
+     * the dependency information from the node.
+     *
+     * @param node {@link DependencyNode} to convert to {@link Artifact}
+     * @return target artifact
+     */
+    public static Artifact toArtifact(DependencyNode node) {
+        Artifact artifact = RepositoryUtils.toArtifact(node.getArtifact());
+        ofNullable(node.getDependency()).ifPresent(dependency -> {
+            ofNullable(dependency.getScope()).ifPresent(artifact::setScope);
+            artifact.setOptional(dependency.isOptional());
+        });
+        return artifact;
     }
 
     /**
-     * Checks the set of dependencies against the list of patterns.
+     * Retrieves the {@link DependencyNode} instance containing the result of the transitive dependency
+     * for the current {@link MavenProject}.
      *
-     * @param thePatterns the patterns
-     * @param dependencies the dependencies
+     * @param helper (may not be null) an instance of the {@link EnforcerRuleHelper} class
+     * @param selectors zero or more {@link DependencySelector} instances
+     * @return a Dependency Node which is the root of the project's dependency tree
+     * @throws EnforcerRuleException thrown if the lookup fails
+     */
+    public static DependencyNode resolveTransitiveDependencies(
+            EnforcerRuleHelper helper, DependencySelector... selectors) throws EnforcerRuleException {
+        try {
+            RepositorySystem repositorySystem = helper.getComponent(RepositorySystem.class);
+            MavenSession session = (MavenSession) helper.evaluate("${session}");
+            MavenProject project = session.getCurrentProject();
+            ArtifactTypeRegistry artifactTypeRegistry =
+                    session.getRepositorySession().getArtifactTypeRegistry();
+
+            DefaultRepositorySystemSession repositorySystemSession =
+                    new DefaultRepositorySystemSession(session.getRepositorySession());
+            repositorySystemSession.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, true);
+            repositorySystemSession.setConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, true);
+            if (selectors.length > 0) {
+                repositorySystemSession.setDependencySelector(new AndDependencySelector(selectors));
+            }
+
+            CollectRequest collectRequest = new CollectRequest(
+                    project.getDependencies().stream()
+                            .map(d -> RepositoryUtils.toDependency(d, artifactTypeRegistry))
+                            .collect(Collectors.toList()),
+                    ofNullable(project.getDependencyManagement())
+                            .map(DependencyManagement::getDependencies)
+                            .map(list -> list.stream()
+                                    .map(d -> RepositoryUtils.toDependency(d, artifactTypeRegistry))
+                                    .collect(Collectors.toList()))
+                            .orElse(null),
+                    project.getRemoteProjectRepositories());
+            Artifact artifact = project.getArtifact();
+            collectRequest.setRootArtifact(RepositoryUtils.toArtifact(artifact));
+
+            return repositorySystem
+                    .collectDependencies(repositorySystemSession, collectRequest)
+                    .getRoot();
+        } catch (ExpressionEvaluationException | ComponentLookupException e) {
+            throw new EnforcerRuleException("Unable to lookup a component " + e.getLocalizedMessage(), e);
+        } catch (DependencyCollectionException e) {
+            throw new EnforcerRuleException("Could not build dependency tree " + e.getLocalizedMessage(), e);
+        }
+    }
+
+    /**
+     * <p>Retrieves all <em>child</em> dependency artifacts from the given {@link DependencyNode} and returns them
+     * as a set of {@link Artifact}.</p>
+     * <p><u>Note:</u>&nbsp;Thus, the result will not contain the root artifact.</p>
+     * @param node root node
+     * @return set of all <em>child</em> dependency artifacts
+     */
+    public static Set<Artifact> getDependencyArtifacts(DependencyNode node) {
+        return getDependencyArtifacts(node, new HashSet<>());
+    }
+
+    private static Set<Artifact> getDependencyArtifacts(DependencyNode node, Set<Artifact> set) {
+        node.getChildren().forEach(child -> {
+            set.add(toArtifact(child));
+            getDependencyArtifacts(child, set);
+        });
+        return set;
+    }
+
+    /**
+     * Returns a subset of dependency artifacts that match the given collection of patterns
+     *
+     * @param dependencies dependency artifacts to match against patterns
+     * @param patterns patterns to match against the artifacts
      * @return a set containing artifacts matching one of the patterns or <code>null</code>
      * @throws EnforcerRuleException the enforcer rule exception
      */
-    public static Set<Artifact> checkDependencies(Set<Artifact> dependencies, List<String> thePatterns)
+    public static Set<Artifact> filterDependencyArtifacts(Set<Artifact> dependencies, Collection<String> patterns)
             throws EnforcerRuleException {
-        Set<Artifact> foundMatches = null;
-
-        if (thePatterns != null && thePatterns.size() > 0) {
-
-            for (String pattern : thePatterns) {
-                String[] subStrings = pattern.split(":");
-                subStrings = StringUtils.stripAll(subStrings);
-                String resultPattern = StringUtils.join(subStrings, ":");
-
-                for (Artifact artifact : dependencies) {
-                    if (compareDependency(resultPattern, artifact)) {
-                        // only create if needed
-                        if (foundMatches == null) {
-                            foundMatches = new HashSet<Artifact>();
-                        }
-                        foundMatches.add(artifact);
-                    }
-                }
+        try {
+            return ofNullable(patterns)
+                    .map(collection -> collection.stream()
+                            .map(p -> p.split(":"))
+                            .map(StringUtils::stripAll)
+                            .map(arr -> String.join(":", arr))
+                            .flatMap(pattern ->
+                                    dependencies.stream().filter(artifact -> compareDependency(pattern, artifact)))
+                            .collect(Collectors.toSet()))
+                    .orElse(null);
+        } catch (IllegalArgumentException e) {
+            if (e.getCause() instanceof InvalidVersionSpecificationException) {
+                throw new EnforcerRuleException(e.getMessage());
             }
+            throw e;
         }
-        return foundMatches;
+    }
+
+    /**
+     * Checks if the given dependency artifact matches the given collection of patterns
+     *
+     * @param artifact dependency artifact to match against patterns
+     * @param patterns patterns to match against the artifacts
+     * @return {@code true} if the given artifact matches the set of patterns
+     */
+    public static boolean matchDependencyArtifact(Artifact artifact, Collection<String> patterns) {
+        try {
+            return ofNullable(patterns)
+                    .map(collection -> collection.stream()
+                            .map(p -> p.split(":"))
+                            .map(StringUtils::stripAll)
+                            .map(arr -> String.join(":", arr))
+                            .anyMatch(pattern -> compareDependency(pattern, artifact)))
+                    .orElse(false);
+        } catch (IllegalArgumentException e) {
+            if (e.getCause() instanceof InvalidVersionSpecificationException) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+            throw e;
+        }
     }
 
     /**
@@ -91,18 +200,8 @@ public final class ArtifactUtils {
      * @param pattern The pattern to compare the artifact with.
      * @param artifact the artifact
      * @return <code>true</code> if the artifact matches one of the patterns
-     * @throws EnforcerRuleException the enforcer rule exception
      */
-    static boolean compareDependency(String pattern, Artifact artifact) throws EnforcerRuleException {
-
-        ArtifactMatcher.Pattern am = new Pattern(pattern);
-        boolean result;
-        try {
-            result = am.match(artifact);
-        } catch (InvalidVersionSpecificationException e) {
-            throw new EnforcerRuleException("Invalid Version Range: ", e);
-        }
-
-        return result;
+    static boolean compareDependency(String pattern, Artifact artifact) {
+        return new Pattern(pattern).match(artifact);
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/EnforcerRuleUtils.java
@@ -19,16 +19,10 @@
 package org.apache.maven.plugins.enforcer.utils;
 
 import java.util.List;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 /**
  * The Class EnforcerRuleUtils.
@@ -36,48 +30,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
 public class EnforcerRuleUtils {
-
-    /** The resolver. */
-    ArtifactResolver resolver;
-
-    /** The local. */
-    ArtifactRepository local;
-
-    /** The remote repositories. */
-    List<ArtifactRepository> remoteRepositories;
-
-    /** The log. */
-    Log log;
-
-    /** The project. */
-    MavenProject project;
-
     private EnforcerRuleHelper helper;
-
-    /**
-     * Instantiates a new enforcer rule utils.
-     *
-     * @param theFactory unused
-     * @param theResolver the the resolver
-     * @param theLocal the the local
-     * @param theRemoteRepositories the the remote repositories
-     * @param project the project
-     * @param theLog the the log
-     */
-    public EnforcerRuleUtils(
-            ArtifactFactory theFactory,
-            ArtifactResolver theResolver,
-            ArtifactRepository theLocal,
-            List<ArtifactRepository> theRemoteRepositories,
-            MavenProject project,
-            Log theLog) {
-        super();
-        this.resolver = theResolver;
-        this.local = theLocal;
-        this.remoteRepositories = theRemoteRepositories;
-        this.log = theLog;
-        this.project = project;
-    }
 
     /**
      * Instantiates a new enforcer rule utils.
@@ -85,19 +38,7 @@ public class EnforcerRuleUtils {
      * @param helper the helper
      */
     public EnforcerRuleUtils(EnforcerRuleHelper helper) {
-
         this.helper = helper;
-        // get the various expressions out of the
-        // helper.
-        try {
-            resolver = helper.getComponent(ArtifactResolver.class);
-            local = (ArtifactRepository) helper.evaluate("${localRepository}");
-            project = (MavenProject) helper.evaluate("${project}");
-            remoteRepositories = project.getRemoteArtifactRepositories();
-        } catch (ComponentLookupException | ExpressionEvaluationException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
     }
 
     private void resolve(Plugin plugin) {

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ParentNodeProvider.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ParentNodeProvider.java
@@ -16,6 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-def buildLog = new File( basedir, 'build.log' ).text
-assert buildLog.contains( '[ERROR] Rule 0: org.apache.maven.plugins.enforcer.BannedPlugins failed with message:' )
-assert buildLog =~ /org.codehaus.mojo:build-helper-maven-plugin:maven-plugin:.* <--- banned plugin/
+package org.apache.maven.plugins.enforcer.utils;
+
+import org.eclipse.aether.graph.DependencyNode;
+
+/**
+ * Provides the information about {@link org.eclipse.aether.graph.DependencyNode} parent nodes
+ */
+public interface ParentNodeProvider {
+
+    /**
+     * Returns the parent node of the given node
+     * @param node node to get the information for
+     * @return parent node or {@code null} is no information is known
+     */
+    DependencyNode getParent(DependencyNode node);
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ParentsVisitor.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/plugins/enforcer/utils/ParentsVisitor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.enforcer.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.DependencyVisitor;
+
+/**
+ * A {@link DependencyVisitor} building a map of parent nodes
+ */
+public class ParentsVisitor implements DependencyVisitor, ParentNodeProvider {
+
+    private final Map<DependencyNode, DependencyNode> parents = new HashMap<>();
+    private final Stack<DependencyNode> parentStack = new Stack<>();
+
+    @Override
+    public DependencyNode getParent(DependencyNode node) {
+        return parents.get(node);
+    }
+
+    @Override
+    public boolean visitEnter(DependencyNode node) {
+        parents.put(node, parentStack.isEmpty() ? null : parentStack.peek());
+        parentStack.push(node);
+        return true;
+    }
+
+    @Override
+    public boolean visitLeave(DependencyNode node) {
+        parentStack.pop();
+        return true;
+    }
+}

--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <description>
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer128_api</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <BannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.maven.plugins.enforcer.its:menforcer128_api</exclude>
+                  </excludes>
+                </BannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/banned-dependencies-fail/verify.groovy
@@ -17,5 +17,4 @@
  * under the License.
  */
 def buildLog = new File( basedir, 'build.log' ).text
-assert buildLog.contains( '[ERROR] Rule 0: org.apache.maven.plugins.enforcer.BannedPlugins failed with message:' )
-assert buildLog =~ /org.codehaus.mojo:build-helper-maven-plugin:maven-plugin:.* <--- banned plugin/
+assert buildLog.contains( 'org.apache.maven.plugins.enforcer.its:menforcer128_api:jar:1.4.0 <--- banned via the exclude/include list' )

--- a/maven-enforcer-plugin/src/it/projects/multimodule-ban-transitive-dependencies_failure/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/multimodule-ban-transitive-dependencies_failure/verify.groovy
@@ -19,4 +19,4 @@
 File buildLog = new File( basedir, 'build.log' )
 
 assert buildLog.text.contains( 'Rule 0: org.apache.maven.plugins.enforcer.BanTransitiveDependencies failed with message:' )
-assert buildLog.text.contains( 'org.apache.maven.its.enforcer:module1:jar:1.0-SNAPSHOT:compile has transitive dependencies:' )
+assert buildLog.text.contains( 'org.apache.maven.its.enforcer:module1:jar:1.0-SNAPSHOT has transitive dependencies:' )

--- a/maven-enforcer-plugin/src/it/projects/multimodule-require-release-dependencies-exclude_failure/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/multimodule-require-release-dependencies-exclude_failure/verify.groovy
@@ -19,4 +19,4 @@
 File buildLog = new File( basedir, 'build.log' )
 
 assert buildLog.text.contains( 'Rule 0: org.apache.maven.plugins.enforcer.RequireReleaseDeps failed with message:' )
-assert buildLog.text.contains( 'Found Banned Dependency: org.apache.maven.its.enforcer:module1:jar:1.0-SNAPSHOT' )
+assert buildLog.text =~ /org.apache.maven.its.enforcer:module1:jar:1.0-SNAPSHOT.*is not a release dependency/


### PR DESCRIPTION
See summary; also: dependency:tree is no longer necessary to check parent information of dependencies which triggered validation failures -- path information is included.

@slawekjaranowski please review