### PR TITLE
[MENFORCER-454] Log warning only if the '-Drules' is actually used

### DIFF
--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
@@ -173,7 +173,10 @@ public class EnforceMojo extends AbstractMojo {
     @Parameter(required = false, property = "rules")
     @Deprecated
     public void setCommandLineRules(List<String> rulesToExecute) throws MojoExecutionException {
-        getLog().warn("Detected the usage of property '-Drules' which is deprecated. Use '-Denforcer.rules' instead.");
+        if (rulesToExecute != null && !rulesToExecute.isEmpty()) {
+            getLog().warn(
+                            "Detected the usage of property '-Drules' which is deprecated. Use '-Denforcer.rules' instead.");
+        }
         setRulesToExecute(rulesToExecute);
     }
 

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/TestEnforceMojo.java
@@ -319,6 +319,17 @@ class TestEnforceMojo {
                 .warn("Detected the usage of property '-Drules' which is deprecated. Use '-Denforcer.rules' instead.");
     }
 
+    @Test
+    void testShouldNotPrintWarnWhenDeprecatedRulesPropertyIsEmpty() throws MojoExecutionException {
+        setupBasics(false);
+
+        Log logSpy = setupLogSpy();
+
+        mojo.setCommandLineRules(Collections.emptyList());
+
+        Mockito.verifyNoInteractions(logSpy);
+    }
+
     private void setupBasics(boolean fail) {
         mojo.setFail(fail);
         mojo.setSession(EnforcerTestUtils.getMavenSession());


### PR DESCRIPTION
* the method gets called with empty list if there is no configuration, resulting in WARNing being printed every single time.
* it somehow slipped in and I only noticed this after merging the main PR.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

