### PR TITLE
[MENFORCER-462] Execute ReactorModuleConvergence only once

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/ReactorModuleConvergence.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/ReactorModuleConvergence.java
@@ -393,6 +393,11 @@ public final class ReactorModuleConvergence extends AbstractStandardEnforcerRule
     }
 
     @Override
+    public String getCacheId() {
+        return String.valueOf(toString().hashCode());
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "ReactorModuleConvergence[message=%s, ignoreModuleDependencies=%b]",

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/ReactorModuleConvergenceTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/ReactorModuleConvergenceTest.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -219,6 +220,11 @@ class ReactorModuleConvergenceTest {
         });
 
         // intentionally no assertTrue() cause we expect getting an exception.
+    }
+
+    @Test
+    void cacheIdShouldBeSet() {
+        assertThat(rule.getCacheId()).isNotEmpty();
     }
 
     /**


### PR DESCRIPTION
Rule checks whole reactor of current build so can be executed once in session

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MENFORCER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MENFORCER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MENFORCER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

