### PR TITLE
[MENFORCER-480] BanDynamicVersions: fix `ignores` parameter

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BanDynamicVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BanDynamicVersions.java
@@ -227,7 +227,7 @@ public final class BanDynamicVersions extends AbstractStandardEnforcerRule {
 
         @Override
         public boolean test(DependencyNode depNode) {
-            return artifactMatcher.match(ArtifactUtils.toArtifact(depNode));
+            return !artifactMatcher.match(ArtifactUtils.toArtifact(depNode));
         }
     }
 

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/pom.xml
@@ -45,6 +45,9 @@
                     <excludedScope>test</excludedScope>
                   </excludedScopes>
                   <allowRangesWithIdenticalBounds>true</allowRangesWithIdenticalBounds>
+                  <ignores>
+                    <ignore>*:menforcer480</ignore>
+                  </ignores>
                 </banDynamicVersions>
               </rules>
             </configuration>
@@ -108,6 +111,12 @@
       <artifactId>menforcer192-a</artifactId>
       <!--  version range syntax with equal upper and lower bounds -->
       <version>[1.0]</version>
+    </dependency>
+    <dependency>
+      <!-- banned transitive version range, but ignored -->
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer480</artifactId>
+      <version>1.0</version>
     </dependency>
   </dependencies>
 

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/pom.xml
@@ -46,7 +46,7 @@
                   </excludedScopes>
                   <allowRangesWithIdenticalBounds>true</allowRangesWithIdenticalBounds>
                   <ignores>
-                    <ignore>*:menforcer480</ignore>
+                    <ignore>*:menforcer134_project</ignore>
                   </ignores>
                 </banDynamicVersions>
               </rules>
@@ -113,10 +113,10 @@
       <version>[1.0]</version>
     </dependency>
     <dependency>
-      <!-- banned transitive version range, but ignored -->
+      <!-- banned SNAPSHOT, but ignored (though it's transitive dependency on menforcer134_modelbuilder is not) -->
       <groupId>org.apache.maven.plugins.enforcer.its</groupId>
-      <artifactId>menforcer480</artifactId>
-      <version>1.0</version>
+      <artifactId>menforcer134_project</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions/verify.groovy
@@ -21,5 +21,6 @@ assert buildLog.text.contains( '[ERROR] Dependency org.apache.maven.plugins.enfo
 assert buildLog.text.contains( '[ERROR] Dependency org.apache.maven.plugins.enforcer.its:menforcer138_io:jar:LATEST (compile) is referenced with a banned dynamic version LATEST' )
 assert buildLog.text.contains( '[ERROR] Dependency org.apache.maven.plugins.enforcer.its:menforcer134_model:jar:1.0-SNAPSHOT (compile) is referenced with a banned dynamic version 1.0-SNAPSHOT' )
 assert buildLog.text.contains( '[ERROR] Dependency org.apache.maven.plugins.enforcer.its:menforcer427-a:jar:1.0 (compile) via org.apache.maven.plugins.enforcer.its:menforcer427:jar:1.0 is referenced with a banned dynamic version [1.0,2)' )
+assert buildLog.text.contains( 'Dependency org.apache.maven.plugins.enforcer.its:menforcer134_modelbuilder:jar:1.0-SNAPSHOT (compile) via org.apache.maven.plugins.enforcer.its:menforcer134_project:jar:1.0-SNAPSHOT is referenced with a banned dynamic version 1.0-SNAPSHOT' )
 assert buildLog.text.contains( '[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.BanDynamicVersions failed with message' )
-assert buildLog.text.contains( 'ERROR] Found 4 dependencies with dynamic versions.' )
+assert buildLog.text.contains( 'ERROR] Found 5 dependencies with dynamic versions.' )


### PR DESCRIPTION
Suggested commit message:
```
[MENFORCER-480] BanDynamicVersions: fix `ignores` parameter

Matching artifacts should be _excluded_ rather than included.
```

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
