### PR TITLE
[MENFORCER-481] BanDynamicVersions: make `excludedScopes` optional

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BanDynamicVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BanDynamicVersions.java
@@ -99,7 +99,7 @@ public final class BanDynamicVersions extends AbstractStandardEnforcerRule {
     /**
      * the scopes of dependencies which should be excluded from this rule
      */
-    private List<String> excludedScopes;
+    private List<String> excludedScopes = Collections.emptyList();
 
     /**
      * Specify the ignored dependencies. This can be a list of artifacts in the format

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.enforcer</groupId>
+  <artifactId>ban-dynamic-versions-test</artifactId>
+  <version>1.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banDynamicVersions/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+        <artifactId>menforcer138_archiver</artifactId>
+        <!-- non applicable dependency management (only affects transitive not direct ones) -->
+        <version>2.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+        <artifactId>menforcer138_utils</artifactId>
+        <version>[1.0,5]</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+        <artifactId>menforcer427-b</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer138_archiver</artifactId>
+      <version>[1.3,2.1.1]</version> <!-- banned dynamic version range -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.enforcer.its</groupId>
+      <artifactId>menforcer138_utils</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-dynamic-versions-scope-all-scopes/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( '[ERROR] Dependency org.apache.maven.plugins.enforcer.its:menforcer138_archiver:jar:2.1.1 (provided) is referenced with a banned dynamic version [1.3,2.1.1]' )
+assert buildLog.text.contains( 'Dependency org.apache.maven.plugins.enforcer.its:menforcer138_utils:jar:3.0 (test) is referenced with a banned dynamic version [1.0,5]' )
+assert buildLog.text.contains( '[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.BanDynamicVersions failed with message' )
+assert buildLog.text.contains( 'ERROR] Found 2 dependencies with dynamic versions.' )


### PR DESCRIPTION
Suggested commit message:
```
[MENFORCER-481] BanDynamicVersions: make `excludedScopes` optional

With these changes, omission of `excludedScopes` no longer causes an NPE.
```

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
