### PR TITLE
[MENFORCER-490] Remove unused dependency

### DIFF
--- a/maven-enforcer-extension/pom.xml
+++ b/maven-enforcer-extension/pom.xml
@@ -49,13 +49,6 @@
       <artifactId>plexus-xml</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <!-- needed for IT tests -->
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-enforcer-plugin</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
ITs passed locally so this doesn't appear to be needed. 

If it is needed we'll need to figure out how to properly exclude this from the dependency analyzer