### PR TITLE
Use constant 3.6.3 in prerequisites/maven as minimal Maven version

### DIFF
--- a/maven-enforcer-plugin/pom.xml
+++ b/maven-enforcer-plugin/pom.xml
@@ -35,7 +35,7 @@
   <description>The Loving Iron Fist of Maven</description>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <dependencies>


### PR DESCRIPTION
It will allow declaring a newer version of Maven dependencies in the project.
