### PR TITLE
`RequireSameVersions` rule: consider entries in `<plugins>`  when analyzing build- and report-plugins

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
@@ -128,6 +128,22 @@ public final class RequireSameVersions extends AbstractStandardEnforcerRule {
         return versionMembers;
     }
 
+    void addDependency(String dependency) {
+        dependencies.add(dependency);
+    }
+
+    void addPlugin(String plugin) {
+        plugins.add(plugin);
+    }
+
+    void addBuildPlugin(String buildPlugin) {
+        buildPlugins.add(buildPlugin);
+    }
+
+    void addReportPlugin(String reportPlugin) {
+        reportPlugins.add(reportPlugin);
+    }
+
     @Override
     public String toString() {
         return String.format(

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
@@ -118,10 +118,9 @@ public final class RequireSameVersions extends AbstractStandardEnforcerRule {
             for (Pattern regEx : regExs) {
                 if (regEx.matcher(artifact.getDependencyConflictId()).matches()) {
                     String version = uniqueVersions ? artifact.getVersion() : artifact.getBaseVersion();
-                    if (!versionMembers.containsKey(version)) {
-                        versionMembers.put(version, new ArrayList<>());
-                    }
-                    versionMembers.get(version).add(artifact.getDependencyConflictId() + source);
+                    versionMembers
+                            .computeIfAbsent(version, unused -> new ArrayList<>())
+                            .add(artifact.getDependencyConflictId() + source);
                 }
             }
         }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireSameVersions.java
@@ -69,10 +69,14 @@ public final class RequireSameVersions extends AbstractStandardEnforcerRule {
         // consider including profile based artifacts
         Map<String, List<String>> versionMembers = new LinkedHashMap<>();
 
+        Set<String> allBuildPlugins = new HashSet<>(buildPlugins);
+        allBuildPlugins.addAll(plugins);
+        Set<String> allReportPlugins = new HashSet<>(reportPlugins);
+        allReportPlugins.addAll(plugins);
         // CHECKSTYLE_OFF: LineLength
         versionMembers.putAll(collectVersionMembers(project.getArtifacts(), dependencies, " (dependency)"));
-        versionMembers.putAll(collectVersionMembers(project.getPluginArtifacts(), buildPlugins, " (buildPlugin)"));
-        versionMembers.putAll(collectVersionMembers(project.getReportArtifacts(), reportPlugins, " (reportPlugin)"));
+        versionMembers.putAll(collectVersionMembers(project.getPluginArtifacts(), allBuildPlugins, " (buildPlugin)"));
+        versionMembers.putAll(collectVersionMembers(project.getReportArtifacts(), allReportPlugins, " (reportPlugin)"));
         // CHECKSTYLE_ON: LineLength
 
         if (versionMembers.size() > 1) {

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.testing.ArtifactStubFactory;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The Class TestRequireSameVersions.
+ *
+ * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
+ */
+class TestRequireSameVersions {
+    private static final ArtifactStubFactory ARTIFACT_FACTORY = new ArtifactStubFactory();
+
+    private MavenProject project;
+    private RequireSameVersions rule;
+
+    @BeforeEach
+    void setup() {
+        project = mock(MavenProject.class);
+        rule = new RequireSameVersions(project, mock(MavenSession.class));
+    }
+
+    @Test
+    void testProjectWithSameVersionsInBuildAndReport() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", version);
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addBuildPlugin(extractGaString(buildPluginOne));
+        rule.addBuildPlugin(extractGaString(buildPluginTwo));
+        rule.addReportPlugin(extractGaString(reportPluginOne));
+        rule.addReportPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testProjectWithSameVersionsInPlugins() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", version);
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addPlugin(extractGaString(buildPluginOne));
+        rule.addPlugin(extractGaString(buildPluginTwo));
+        rule.addPlugin(extractGaString(reportPluginOne));
+        rule.addPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testProjectWithSameVersionsInBuildAndReportAndPlugins() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", version);
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addBuildPlugin(extractGaString(buildPluginOne));
+        rule.addPlugin(extractGaString(buildPluginTwo));
+        rule.addReportPlugin(extractGaString(reportPluginOne));
+        rule.addPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testProjectWithDifferentPluginVersionsInBuildAndReport() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", "1.0.1");
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addBuildPlugin(extractGaString(buildPluginOne));
+        rule.addBuildPlugin(extractGaString(buildPluginTwo));
+        rule.addReportPlugin(extractGaString(reportPluginOne));
+        rule.addReportPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).isInstanceOf(EnforcerRuleException.class);
+    }
+
+    @Test
+    void testProjectWithDifferentPluginVersionsInPlugins() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", "1.0.1");
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addPlugin(extractGaString(buildPluginOne));
+        rule.addPlugin(extractGaString(buildPluginTwo));
+        rule.addPlugin(extractGaString(reportPluginOne));
+        rule.addPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).isInstanceOf(EnforcerRuleException.class);
+    }
+
+    @Test
+    void testProjectWithDifferentPluginVersionsInBuildAndReportAndPlugins() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", version);
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", "1.0.1");
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addBuildPlugin(extractGaString(buildPluginOne));
+        rule.addPlugin(extractGaString(buildPluginTwo));
+        rule.addReportPlugin(extractGaString(reportPluginOne));
+        rule.addPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).isInstanceOf(EnforcerRuleException.class);
+    }
+
+    @Test
+    void testProjectWithDifferentDependencyVersionsInBuildAndReportAndPlugins() throws IOException {
+        String version = "1.0.0";
+        Artifact dependency = constructArtifact("acme-dependency", "1.0.1");
+        Artifact buildPluginOne = constructArtifact("acme-build-plugin-one", version);
+        Artifact buildPluginTwo = constructArtifact("acme-build-plugin-two", version);
+        Artifact reportPluginOne = constructArtifact("acme-report-plugin-one", version);
+        Artifact reportPluginTwo = constructArtifact("acme-report-plugin-two", version);
+        rule.addDependency(extractGaString(dependency));
+        rule.addBuildPlugin(extractGaString(buildPluginOne));
+        rule.addPlugin(extractGaString(buildPluginTwo));
+        rule.addReportPlugin(extractGaString(reportPluginOne));
+        rule.addPlugin(extractGaString(reportPluginTwo));
+
+        HashSet<Artifact> dependencies = new HashSet<>();
+        dependencies.add(dependency);
+        HashSet<Artifact> pluginArtifacts = new HashSet<>();
+        pluginArtifacts.add(buildPluginOne);
+        pluginArtifacts.add(buildPluginTwo);
+        HashSet<Artifact> reportArtifacts = new HashSet<>();
+        reportArtifacts.add(reportPluginOne);
+        reportArtifacts.add(reportPluginTwo);
+        when(project.getArtifacts()).thenReturn(dependencies);
+        when(project.getPluginArtifacts()).thenReturn(pluginArtifacts);
+        when(project.getReportArtifacts()).thenReturn(reportArtifacts);
+
+        assertThatCode(rule::execute).isInstanceOf(EnforcerRuleException.class);
+    }
+
+    private static Artifact constructArtifact(String artifactId, String version) throws IOException {
+        return ARTIFACT_FACTORY.createArtifact("org.acme", artifactId, version);
+    }
+
+    private static String extractGaString(Artifact dependency) {
+        return String.format("%s:%s", dependency.getGroupId(), dependency.getArtifactId());
+    }
+}

--- a/maven-enforcer-plugin/src/it/projects/require-same-versions_failure/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-same-versions_failure/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def buildLog = new File(basedir, 'build.log').text
+
+assert buildLog.contains('[INFO] BUILD FAILURE')
+assert buildLog.contains('ERROR] Rule 0: org.apache.maven.enforcer.rules.RequireSameVersions failed with message:')
+assert buildLog.contains('ERROR] Rule 1: org.apache.maven.enforcer.rules.RequireSameVersions failed with message:')
+
+// two rules so message will be reported twice
+assert buildLog.count('[ERROR] - org.apache.maven.plugins:maven-surefire-plugin:maven-plugin (buildPlugin)') == 2
+assert buildLog.count('[ERROR] - org.apache.maven.plugins:maven-failsafe-plugin:maven-plugin (buildPlugin)') == 2
+assert buildLog.count('[ERROR] - org.apache.maven.plugins:maven-surefire-report-plugin:maven-plugin (reportPlugin)') == 2


### PR DESCRIPTION
Resolves #372 

### `RequireSameVersion` rule
 if plugins are analyzed, entries under `<plugins>` must be considered f
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
