### PR TITLE
Remove the from parameter names

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/BanDependencyManagementScope.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/BanDependencyManagementScope.java
@@ -113,8 +113,8 @@ public final class BanDependencyManagementScope extends AbstractStandardEnforcer
                 + System.lineSeparator();
     }
 
-    public void setExcludes(List<String> theExcludes) {
-        this.excludes = theExcludes;
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireJavaVendor.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireJavaVendor.java
@@ -96,10 +96,10 @@ public final class RequireJavaVendor extends AbstractStandardEnforcerRule {
      * java.vendor, which you can also see with mvn --version. <br>
      * Excludes override the include rules.
      *
-     * @param theExcludes the vendors to exclude from the include list
+     * @param excludes the vendors to exclude from the include list
      */
-    public void setExcludes(List<String> theExcludes) {
-        this.excludes = theExcludes;
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
     }
 
     /**
@@ -114,12 +114,12 @@ public final class RequireJavaVendor extends AbstractStandardEnforcerRule {
      * <li><code>Amazon</code> prohibits vendor name Amazon </li>
      * </ul>
      *
-     * @param theIncludes the list of required vendors
+     * @param includes the list of required vendors
      *
      * @see #setExcludes(List)
      */
-    public void setIncludes(List<String> theIncludes) {
-        this.includes = theIncludes;
+    public void setIncludes(List<String> includes) {
+        this.includes = includes;
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireOS.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequireOS.java
@@ -231,52 +231,52 @@ public final class RequireOS extends AbstractStandardEnforcerRule {
      * </ul>
      * Note: '!' is allowed at the beginning of the string and still considered valid.
      *
-     * @param theFamily the family to check.
-     * @return true if one of the valid families.
+     * @param family the family to check
+     * @return true if one of the valid families
      */
-    public boolean isValidFamily(String theFamily) {
+    public boolean isValidFamily(String family) {
 
         // in case they are checking !family
-        theFamily = StringUtils.stripStart(theFamily, "!");
+        family = StringUtils.stripStart(family, "!");
 
-        return (theFamily == null || theFamily.isEmpty())
-                || Os.getValidFamilies().contains(theFamily);
+        return (family == null || family.isEmpty())
+                || Os.getValidFamilies().contains(family);
     }
 
     /**
-     * Sets the arch.
+     * Sets the architecture.
      *
-     * @param theArch the arch to set
+     * @param architecture the architecture to set
      */
-    public void setArch(String theArch) {
-        this.arch = theArch;
+    public void setArch(String architecture) {
+        this.arch = architecture;
     }
 
     /**
      * Sets the family.
      *
-     * @param theFamily the family to set
+     * @param family the family to set
      */
-    public void setFamily(String theFamily) {
-        this.family = theFamily;
+    public void setFamily(String family) {
+        this.family = family;
     }
 
     /**
      * Sets the name.
      *
-     * @param theName the name to set
+     * @param name the name to set
      */
-    public void setName(String theName) {
-        this.name = theName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
      * Sets the version.
      *
-     * @param theVersion the version to set
+     * @param version the version to set
      */
-    public void setVersion(String theVersion) {
-        this.version = theVersion;
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     /**
@@ -288,7 +288,7 @@ public final class RequireOS extends AbstractStandardEnforcerRule {
 
     @Override
     public String getCacheId() {
-        // return the hashcodes of all the parameters
+        // return the hash codes of all the parameters
         StringBuilder b = new StringBuilder();
         if (version != null && !version.isEmpty()) {
             b.append(version.hashCode());

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequirePluginVersions.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/RequirePluginVersions.java
@@ -475,18 +475,18 @@ public final class RequirePluginVersions extends AbstractStandardEnforcerRule {
      * later than the plugin is executing.
      *
      * @param project   the project
-     * @param thePhases the phases
+     * @param phases the phases
      * @return the bound plugins
      * @throws PluginNotFoundException     the plugin not found exception
      * @throws LifecycleExecutionException the lifecycle execution exception
      */
-    private Set<Plugin> getBoundPlugins(MavenProject project, String thePhases)
+    private Set<Plugin> getBoundPlugins(MavenProject project, String phases)
             throws PluginNotFoundException, LifecycleExecutionException {
 
         Set<Plugin> allPlugins = new HashSet<>();
 
         // lookup the bindings for all the passed in phases
-        String[] lifecyclePhases = thePhases.split(",");
+        String[] lifecyclePhases = phases.split(",");
         for (int i = 0; i < lifecyclePhases.length; i++) {
             String lifecyclePhase = lifecyclePhases[i];
             if (lifecyclePhase != null && !lifecyclePhase.isEmpty()) {
@@ -884,19 +884,19 @@ public final class RequirePluginVersions extends AbstractStandardEnforcerRule {
     /**
      * Sets the ban latest.
      *
-     * @param theBanLatest the banLatest to set
+     * @param banLatest the banLatest to set
      */
-    public void setBanLatest(boolean theBanLatest) {
-        this.banLatest = theBanLatest;
+    public void setBanLatest(boolean banLatest) {
+        this.banLatest = banLatest;
     }
 
     /**
      * Sets the ban release.
      *
-     * @param theBanRelease the banRelease to set
+     * @param banRelease the banRelease to set
      */
-    public void setBanRelease(boolean theBanRelease) {
-        this.banRelease = theBanRelease;
+    public void setBanRelease(boolean banRelease) {
+        this.banRelease = banRelease;
     }
 
     /**
@@ -911,19 +911,19 @@ public final class RequirePluginVersions extends AbstractStandardEnforcerRule {
     /**
      * Sets the ban snapshots.
      *
-     * @param theBanSnapshots the banSnapshots to set
+     * @param banSnapshots the banSnapshots to set
      */
-    public void setBanSnapshots(boolean theBanSnapshots) {
-        this.banSnapshots = theBanSnapshots;
+    public void setBanSnapshots(boolean banSnapshots) {
+        this.banSnapshots = banSnapshots;
     }
 
     /**
      * Sets the ban timestamps.
      *
-     * @param theBanTimestamps the banTimestamps to set
+     * @param banTimestamps the banTimestamps to set
      */
-    public void setBanTimestamps(boolean theBanTimestamps) {
-        this.banTimestamps = theBanTimestamps;
+    public void setBanTimestamps(boolean banTimestamps) {
+        this.banTimestamps = banTimestamps;
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase.java
@@ -147,10 +147,10 @@ abstract class BannedDependenciesBase extends AbstractStandardEnforcerRule {
     /**
      * Sets the search transitive.
      *
-     * @param theSearchTransitive the searchTransitive to set
+     * @param searchTransitive the searchTransitive to set
      */
-    public void setSearchTransitive(boolean theSearchTransitive) {
-        this.searchTransitive = theSearchTransitive;
+    public void setSearchTransitive(boolean searchTransitive) {
+        this.searchTransitive = searchTransitive;
     }
 
     /**
@@ -170,10 +170,10 @@ abstract class BannedDependenciesBase extends AbstractStandardEnforcerRule {
      * include rule.
      *
      * @see #getExcludes()
-     * @param theExcludes the excludes to set
+     * @param excludes the excludes to set
      */
-    public void setExcludes(List<String> theExcludes) {
-        this.excludes = theExcludes;
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
     }
 
     /**
@@ -196,10 +196,10 @@ abstract class BannedDependenciesBase extends AbstractStandardEnforcerRule {
      * include "xerces:xerces-api"
      *
      * @see #setIncludes(List)
-     * @param theIncludes the includes to set
+     * @param includes the includes to set
      */
-    public void setIncludes(List<String> theIncludes) {
-        this.includes = theIncludes;
+    public void setIncludes(List<String> includes) {
+        this.includes = includes;
     }
 
     public boolean isSearchTransitive() {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
@@ -222,21 +222,21 @@ public final class ArtifactMatcher {
     }
 
     /**
-     * Copied from Artifact.VersionRange. This is tweaked to handle singular ranges properly. Currently the default
+     * Copied from Artifact.VersionRange. This is tweaked to handle singular ranges properly. The default
      * containsVersion method assumes a singular version means allow everything. This method assumes that "2.0.4" ==
      * "[2.0.4,)"
      *
-     * @param allowedRange range of allowed versions.
-     * @param theVersion   the version to be checked.
-     * @return true if the version is contained by the range.
+     * @param allowedRange range of allowed versions
+     * @param version   the version to be checked
+     * @return true if the version is contained by the range
      */
-    public static boolean containsVersion(VersionRange allowedRange, ArtifactVersion theVersion) {
+    public static boolean containsVersion(VersionRange allowedRange, ArtifactVersion version) {
         ArtifactVersion recommendedVersion = allowedRange.getRecommendedVersion();
         if (recommendedVersion == null) {
-            return allowedRange.containsVersion(theVersion);
+            return allowedRange.containsVersion(version);
         } else {
             // only singular versions ever have a recommendedVersion
-            int compareTo = recommendedVersion.compareTo(theVersion);
+            int compareTo = recommendedVersion.compareTo(version);
             return compareTo <= 0;
         }
     }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/AbstractVersionEnforcer.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/AbstractVersionEnforcer.java
@@ -65,7 +65,6 @@ abstract class AbstractVersionEnforcer extends AbstractStandardEnforcerRule {
             throw new EnforcerRuleException(variableName + " version can't be empty.");
         } else {
 
-            VersionRange vr;
             String msg = "Detected " + variableName + " Version: " + actualVersion;
 
             // short circuit check if the strings are exactly equal
@@ -73,15 +72,15 @@ abstract class AbstractVersionEnforcer extends AbstractStandardEnforcerRule {
                 getLog().debug(msg + " is allowed in the range " + requiredVersionRange + ".");
             } else {
                 try {
-                    vr = VersionRange.createFromVersionSpec(requiredVersionRange);
+                    VersionRange versionRange = VersionRange.createFromVersionSpec(requiredVersionRange);
 
-                    if (containsVersion(vr, actualVersion)) {
-                        getLog().debug(msg + " is allowed in the range " + toString(vr) + ".");
+                    if (containsVersion(versionRange, actualVersion)) {
+                        getLog().debug(msg + " is allowed in the range " + toString(versionRange) + ".");
                     } else {
                         String message = getMessage();
 
                         if (message == null || message.isEmpty()) {
-                            message = msg + " is not in the allowed range " + toString(vr) + ".";
+                            message = msg + " is not in the allowed range " + toString(versionRange) + ".";
                         }
 
                         throw new EnforcerRuleException(message);
@@ -94,19 +93,19 @@ abstract class AbstractVersionEnforcer extends AbstractStandardEnforcerRule {
         }
     }
 
-    protected static String toString(VersionRange vr) {
+    protected static String toString(VersionRange versionRange) {
         // as recommended version is used as lower bound in this context modify the string representation
-        if (vr.getRecommendedVersion() != null) {
-            return "[" + vr.getRecommendedVersion().toString() + ",)";
+        if (versionRange.getRecommendedVersion() != null) {
+            return "[" + versionRange.getRecommendedVersion().toString() + ",)";
         } else {
-            return vr.toString();
+            return versionRange.toString();
         }
     }
 
     @Override
     public String getCacheId() {
         if (version != null && !version.isEmpty()) {
-            // return the hashcodes of the parameter that matters
+            // return the hash codes of the parameter that matters
             return "" + version.hashCode();
         } else {
             return "0";
@@ -132,9 +131,9 @@ abstract class AbstractVersionEnforcer extends AbstractStandardEnforcerRule {
      * <li><code>(,2.0.5],[2.1.1,)</code> Versions up to 2.0.5 (included) and 2.1.1 or higher</li>
      * </ul>
      *
-     * @param theVersion the required version to set
+     * @param version the required version to set
      */
-    public void setVersion(String theVersion) {
-        this.version = theVersion;
+    public void setVersion(String version) {
+        this.version = version;
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/RequireJavaVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/RequireJavaVersion.java
@@ -50,19 +50,19 @@ public final class RequireJavaVersion extends AbstractVersionEnforcer {
     private boolean display = false;
 
     @Override
-    public void setVersion(String theVersion) {
+    public void setVersion(String version) {
 
-        if ("8".equals(theVersion)) {
+        if ("8".equals(version)) {
             super.setVersion("1.8");
             return;
         }
 
-        if (!theVersion.contains("8")) {
-            super.setVersion(theVersion);
+        if (!version.contains("8")) {
+            super.setVersion(version);
             return;
         }
 
-        Matcher matcher = JDK8_VERSION_PATTERN.matcher(theVersion);
+        Matcher matcher = JDK8_VERSION_PATTERN.matcher(version);
 
         StringBuffer result = new StringBuffer();
         while (matcher.find()) {
@@ -102,17 +102,17 @@ public final class RequireJavaVersion extends AbstractVersionEnforcer {
     }
 
     /**
-     * Converts a jdk string from 1.5.0-11b12 to a single 3 digit version like 1.5.0-11
+     * Converts a JDK string from 1.5.0-11b12 to a single 3 digit version like 1.5.0-11
      *
-     * @param theJdkVersion to be converted.
-     * @return the converted string.
+     * @param jdkVersion to be converted
+     * @return the converted string
      */
-    public static String normalizeJDKVersion(String theJdkVersion) {
+    public static String normalizeJDKVersion(String jdkVersion) {
 
-        theJdkVersion = theJdkVersion.replaceAll("_|-", ".");
-        String tokenArray[] = StringUtils.split(theJdkVersion, ".");
+        jdkVersion = jdkVersion.replaceAll("_|-", ".");
+        String tokenArray[] = StringUtils.split(jdkVersion, ".");
         List<String> tokens = Arrays.asList(tokenArray);
-        StringBuilder buffer = new StringBuilder(theJdkVersion.length());
+        StringBuilder buffer = new StringBuilder(jdkVersion.length());
 
         Iterator<String> iter = tokens.iterator();
         for (int i = 0; i < tokens.size() && i < 4; i++) {

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/ReactorModuleConvergenceTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/ReactorModuleConvergenceTest.java
@@ -73,8 +73,8 @@ class ReactorModuleConvergenceTest {
         MavenProject mp2 = createProjectChild1(mp1);
         MavenProject mp3 = createProjectChild2(mp1);
 
-        List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-        setupSortedProjects(theList);
+        List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+        setupSortedProjects(projects);
 
         rule.execute();
     }
@@ -86,8 +86,8 @@ class ReactorModuleConvergenceTest {
             MavenProject mp2 = createProjectChild1(mp1);
             MavenProject mp3 = createProjectChild2WithWrongVersion(mp1);
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(projects);
 
             rule.execute();
 
@@ -102,18 +102,18 @@ class ReactorModuleConvergenceTest {
         assertThrows(EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
 
-            MavenProject wrongParentVerison = mock(MavenProject.class);
-            when(wrongParentVerison.getGroupId()).thenReturn("org.apache.enforcer");
-            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
-            when(wrongParentVerison.getVersion()).thenReturn("1.1-SNAPSHOT");
-            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.1-SNAPSHOT");
-            when(wrongParentVerison.getDependencies()).thenReturn(Collections.emptyList());
+            MavenProject wrongParentVersion = mock(MavenProject.class);
+            when(wrongParentVersion.getGroupId()).thenReturn("org.apache.enforcer");
+            when(wrongParentVersion.getArtifactId()).thenReturn("m1");
+            when(wrongParentVersion.getVersion()).thenReturn("1.1-SNAPSHOT");
+            when(wrongParentVersion.getId()).thenReturn("org.apache.enforcer:m1:jar:1.1-SNAPSHOT");
+            when(wrongParentVersion.getDependencies()).thenReturn(Collections.emptyList());
 
-            MavenProject mp2 = createProjectChild2(wrongParentVerison);
+            MavenProject mp2 = createProjectChild2(wrongParentVersion);
             MavenProject mp3 = createProjectChild2(mp1);
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(projects);
 
             rule.execute();
 
@@ -131,8 +131,8 @@ class ReactorModuleConvergenceTest {
         MavenProject mp2 = createProjectChild1(mp1);
         MavenProject mp3 = createProjectChild2(mp1);
 
-        List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-        setupSortedProjects(theList);
+        List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+        setupSortedProjects(projects);
 
         rule.execute();
     }
@@ -144,8 +144,8 @@ class ReactorModuleConvergenceTest {
             MavenProject mp2 = createProjectChild1(mp1);
             MavenProject mp3 = createProjectChild2(null);
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(projects);
 
             rule.execute();
         });
@@ -156,18 +156,18 @@ class ReactorModuleConvergenceTest {
         assertThrows(EnforcerRuleException.class, () -> {
             MavenProject mp1 = createProjectParent();
 
-            MavenProject wrongParentVerison = mock(MavenProject.class);
-            when(wrongParentVerison.getGroupId()).thenReturn("org.apache");
-            when(wrongParentVerison.getArtifactId()).thenReturn("m1");
-            when(wrongParentVerison.getVersion()).thenReturn("1.0-SNAPSHOT");
-            when(wrongParentVerison.getId()).thenReturn("org.apache.enforcer:m1:jar:1.0-SNAPSHOT");
-            when(wrongParentVerison.getDependencies()).thenReturn(Collections.emptyList());
+            MavenProject wrongParentVersion = mock(MavenProject.class);
+            when(wrongParentVersion.getGroupId()).thenReturn("org.apache");
+            when(wrongParentVersion.getArtifactId()).thenReturn("m1");
+            when(wrongParentVersion.getVersion()).thenReturn("1.0-SNAPSHOT");
+            when(wrongParentVersion.getId()).thenReturn("org.apache.enforcer:m1:jar:1.0-SNAPSHOT");
+            when(wrongParentVersion.getDependencies()).thenReturn(Collections.emptyList());
 
-            MavenProject mp2 = createProjectChild2(wrongParentVerison);
+            MavenProject mp2 = createProjectChild2(wrongParentVersion);
             MavenProject mp3 = createProjectChild2(mp1);
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(projects);
 
             rule.execute();
 
@@ -191,8 +191,8 @@ class ReactorModuleConvergenceTest {
         List<Dependency> depListMP3 = Arrays.asList(dep1Mp3);
         when(mp3.getDependencies()).thenReturn(depListMP3);
 
-        List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-        setupSortedProjects(theList);
+        List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+        setupSortedProjects(projects);
 
         rule.execute();
     }
@@ -211,8 +211,8 @@ class ReactorModuleConvergenceTest {
 
             MavenProject mp3 = createProjectChild2(mp1);
 
-            List<MavenProject> theList = Arrays.asList(mp1, mp2, mp3);
-            setupSortedProjects(theList);
+            List<MavenProject> projects = Arrays.asList(mp1, mp2, mp3);
+            setupSortedProjects(projects);
 
             rule.execute();
 

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequirePluginVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequirePluginVersions.java
@@ -471,13 +471,13 @@ class TestRequirePluginVersions {
      *
      * @param group    the group
      * @param artifact the artifact
-     * @param theSet   the set
+     * @param plugins   the set
      */
-    private void assertContainsPlugin(String group, String artifact, Collection<Plugin> theSet) {
-        Plugin p = new Plugin();
-        p.setGroupId(group);
-        p.setArtifactId(artifact);
-        assertTrue(theSet.contains(p));
+    private void assertContainsPlugin(String group, String artifact, Collection<Plugin> plugins) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(group);
+        plugin.setArtifactId(artifact);
+        assertTrue(plugins.contains(plugin));
     }
 
     /**
@@ -485,13 +485,13 @@ class TestRequirePluginVersions {
      *
      * @param group    the group
      * @param artifact the artifact
-     * @param theSet   the the set
+     * @param plugins   the set
      */
-    private void assertNotContainPlugin(String group, String artifact, Collection<Plugin> theSet) {
-        Plugin p = new Plugin();
-        p.setGroupId(group);
-        p.setArtifactId(artifact);
-        assertFalse(theSet.contains(p));
+    private void assertNotContainPlugin(String group, String artifact, Collection<Plugin> plugins) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(group);
+        plugin.setArtifactId(artifact);
+        assertFalse(plugins.contains(plugin));
     }
 
     /**

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/MockEnforcerExpressionEvaluator.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/MockEnforcerExpressionEvaluator.java
@@ -30,19 +30,19 @@ public class MockEnforcerExpressionEvaluator extends PluginParameterExpressionEv
     /**
      * Instantiates a new mock enforcer expression evaluator.
      *
-     * @param theContext the context
+     * @param context the context
      */
-    public MockEnforcerExpressionEvaluator(MavenSession theContext) {
-        super(theContext, new MojoExecution(new MojoDescriptor()));
+    public MockEnforcerExpressionEvaluator(MavenSession context) {
+        super(context, new MojoExecution(new MojoDescriptor()));
     }
 
     @Override
-    public Object evaluate(String expr) {
-        if (expr != null) {
+    public Object evaluate(String expression) {
+        if (expression != null) {
             // just remove the ${ } and return the name as the value
-            return expr.replaceAll("\\$\\{|}", "");
+            return expression.replaceAll("\\$\\{|}", "");
         } else {
-            return expr;
+            return expression;
         }
     }
 }

--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/EnforceMojo.java
@@ -444,17 +444,17 @@ public class EnforceMojo extends AbstractMojo {
     }
 
     /**
-     * @param theFail the fail to set
+     * @param fail whether to fail
      */
-    public void setFail(boolean theFail) {
-        this.fail = theFail;
+    public void setFail(boolean fail) {
+        this.fail = fail;
     }
 
     /**
-     * @param theFailFast the failFast to set
+     * @param failFast whether to fail fast
      */
-    public void setFailFast(boolean theFailFast) {
-        this.failFast = theFailFast;
+    public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
     }
 
     private String createRuleMessage(
@@ -492,9 +492,9 @@ public class EnforceMojo extends AbstractMojo {
     }
 
     /**
-     * @param thefailIfNoRules the failIfNoRules to set
+     * @param failIfNoRules whether to fsail if there are no rules
      */
-    public void setFailIfNoRules(boolean thefailIfNoRules) {
-        this.failIfNoRules = thefailIfNoRules;
+    public void setFailIfNoRules(boolean failIfNoRules) {
+        this.failIfNoRules = failIfNoRules;
     }
 }

--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/DefaultEnforcementRuleHelper.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/DefaultEnforcementRuleHelper.java
@@ -79,13 +79,13 @@ public class DefaultEnforcementRuleHelper implements EnforcerRuleHelper {
     }
 
     @Override
-    public File alignToBaseDirectory(File theFile) {
-        return evaluator.alignToBaseDirectory(theFile);
+    public File alignToBaseDirectory(File file) {
+        return evaluator.alignToBaseDirectory(file);
     }
 
     @Override
-    public Object evaluate(String theExpression) throws ExpressionEvaluationException {
-        return evaluator.evaluate(theExpression);
+    public Object evaluate(String expression) throws ExpressionEvaluationException {
+        return evaluator.evaluate(expression);
     }
 
     @Override
@@ -94,23 +94,23 @@ public class DefaultEnforcementRuleHelper implements EnforcerRuleHelper {
     }
 
     @Override
-    public Object getComponent(String theComponentKey) throws ComponentLookupException {
-        return container.lookup(theComponentKey);
+    public Object getComponent(String componentKey) throws ComponentLookupException {
+        return container.lookup(componentKey);
     }
 
     @Override
-    public Object getComponent(String theRole, String theRoleHint) throws ComponentLookupException {
-        return container.lookup(theRole, theRoleHint);
+    public Object getComponent(String role, String roleHint) throws ComponentLookupException {
+        return container.lookup(role, roleHint);
     }
 
     @Override
-    public List<Object> getComponentList(String theRole) throws ComponentLookupException {
-        return container.lookupList(theRole);
+    public List<Object> getComponentList(String role) throws ComponentLookupException {
+        return container.lookupList(role);
     }
 
     @Override
-    public Map<String, Object> getComponentMap(String theRole) throws ComponentLookupException {
-        return container.lookupMap(theRole);
+    public Map<String, Object> getComponentMap(String role) throws ComponentLookupException {
+        return container.lookupMap(role);
     }
 
     @Override

--- a/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/MockEnforcerRule.java
+++ b/maven-enforcer-plugin/src/test/java/org/apache/maven/plugins/enforcer/MockEnforcerRule.java
@@ -63,10 +63,10 @@ public class MockEnforcerRule implements EnforcerRule {
     }
 
     /**
-     * @param theFailRule the failRule to set
+     * @param failRule the failRule to set
      */
-    public void setFailRule(boolean theFailRule) {
-        this.failRule = theFailRule;
+    public void setFailRule(boolean failRule) {
+        this.failRule = failRule;
     }
 
     /**


### PR DESCRIPTION
This is some very old variable naming style inherited from C/C++ that never caught in Java.  