### PR TITLE
Fix NPE when a classifier part is specified in bannedDependencies

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
@@ -145,6 +145,10 @@ public final class ArtifactMatcher {
         }
 
         private boolean matches(int index, String input) {
+            // TODO: Check if this can be done better or prevented earlier.
+            if (input == null) {
+                input = "";
+            }
             //          return matches(parts[index], input);
             if (partsRegex[index] == null) {
                 String regex = parts[index]
@@ -157,10 +161,6 @@ public final class ArtifactMatcher {
                         .replace("(", "\\(")
                         .replace(")", "\\)");
 
-                // TODO: Check if this can be done better or prevented earlier.
-                if (input == null) {
-                    input = "";
-                }
                 partsRegex[index] = java.util.regex.Pattern.compile(regex);
             }
             return partsRegex[index].matcher(input).matches();

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
@@ -58,6 +58,19 @@ class BannedDependenciesTest {
     private BannedDependencies rule;
 
     @Test
+    void excludesDoNotUseTransitiveDependenciesNullSafe() throws Exception {
+        when(session.getCurrentProject()).thenReturn(project);
+        when(project.getDependencyArtifacts()).thenReturn(ARTIFACT_STUB_FACTORY.getTypedArtifacts());
+
+        rule.setSearchTransitive(false);
+        rule.setExcludes(Collections.singletonList("g:b:*:*:compile:*"));
+
+        assertThatCode(rule::execute)
+                .isInstanceOf(EnforcerRuleException.class)
+                .hasMessageContaining("g:b:jar:1.0 <--- banned via the exclude/include list");
+    }
+
+    @Test
     void excludesDoNotUseTransitiveDependencies() throws Exception {
         when(session.getCurrentProject()).thenReturn(project);
         when(project.getDependencyArtifacts()).thenReturn(ARTIFACT_STUB_FACTORY.getScopedArtifacts());


### PR DESCRIPTION
Fixes NPE when a classifier part is specified in the matching criteria but an artifact classifier is null rather than empty.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
