### PR TITLE
Correct support parameters documentation for banned repositories rule

### DIFF
--- a/enforcer-rules/src/site/apt/bannedRepositories.apt.vm
+++ b/enforcer-rules/src/site/apt/bannedRepositories.apt.vm
@@ -35,9 +35,9 @@ Banned Specified Repositories
 
 * Support Parameters
 
-   * <<banRepositories>> - Specify banned non-plugin repositories. This is a black list of http/https url patterns.
+   * <<bannedRepositories>> - Specify banned non-plugin repositories. This is a black list of http/https url patterns.
 
-   * <<banPluginRepositories>> - Specify banned plugin repositories. This is a black list of http/https url patterns.
+   * <<bannedPluginRepositories>> - Specify banned plugin repositories. This is a black list of http/https url patterns.
 
    * <<allowedRepositories>> - Specify explicitly allowed non-plugin repositories. This is a white list of http/https url patterns.
 


### PR DESCRIPTION
PR Description:

This corrects the documentation for the "bannedRepositories" rule to name the parameters correctly, according to the [class ](https://github.com/apache/maven-enforcer/blob/master/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/BannedRepositories.java) that backs the rule.

Specifically, the two parameters `banRepositories` and `banPluginRepositories` should be `bannedRepositories` and `bannedPluginRepositories`, respectively.

---

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
