### PR TITLE
Fix formatting typo in dependencyConvergence.apt.vm

### DIFF
--- a/enforcer-rules/src/site/apt/dependencyConvergence.apt.vm
+++ b/enforcer-rules/src/site/apt/dependencyConvergence.apt.vm
@@ -139,8 +139,8 @@ and
 
 * Timestamped Version
 	
-By default, the non-unique versions are matched, which means the <<<X.Y-SNAPSHOT>>> instead of the timestamped versions.
-If you want to use the unique versions of the dependencies, set the uniqueVersions property to <<<true>>>:
+  By default, the non-unique versions are matched, which means the <<<X.Y-SNAPSHOT>>> instead of the timestamped versions.
+  If you want to use the unique versions of the dependencies, set the uniqueVersions property to <<<true>>>:
 
 +---------------------------------------------
       <dependencyConvergence>


### PR DESCRIPTION
Fixes a small typo in the APT markup for one of the rule descriptions that becomes unreadable on my phone.

![Screenshot_2025-09-08-18-43-51-83_984e1414ae90666a90f12ff17ec14a7f](https://github.com/user-attachments/assets/70f5196b-7a8d-4e42-9964-236a66573e8b)

<small>Apache CLA has been signed and sent in via email for previous contributions.</small>