### PR TITLE
Use SessionData for cache storage

### DIFF
--- a/maven-enforcer-plugin/src/it/projects/require-java-vendor-multi-module/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-java-vendor-multi-module/invoker.properties
@@ -16,5 +16,3 @@
 # under the License.
 
 invoker.goals = -T3 verify
-# SessionScoped not working in older Maven versions
-invoker.maven.version = 3.9.0+

--- a/maven-enforcer-plugin/src/it/projects/require-java-vendor-multi-module/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-java-vendor-multi-module/invoker.properties
@@ -16,3 +16,5 @@
 # under the License.
 
 invoker.goals = -T3 verify
+# SessionScoped not working in older Maven versions
+invoker.maven.version = 3.9.0+

--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache.java
@@ -18,16 +18,19 @@
  */
 package org.apache.maven.plugins.enforcer.internal;
 
-import javax.annotation.PreDestroy;
+import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.maven.SessionScoped;
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.SessionData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,17 +41,19 @@ import org.slf4j.LoggerFactory;
  * @since 3.2.0
  */
 @Named
-@SessionScoped
+@Singleton
 public class EnforcerRuleCache {
 
     private final Logger logger = LoggerFactory.getLogger(EnforcerRuleCache.class);
 
-    private final Map<Class<? extends AbstractEnforcerRule>, List<String>> cache = new HashMap<>();
+    private final Provider<MavenSession> sessionProvider;
 
-    EnforcerRuleCache() {
-        logger.debug("Enforcer rule cache - created");
+    @Inject
+    EnforcerRuleCache(Provider<MavenSession> sessionProvider) {
+        this.sessionProvider = sessionProvider;
     }
 
+    @SuppressWarnings("unchecked")
     public boolean isCached(AbstractEnforcerRule rule) {
 
         String cacheId = rule.getCacheId();
@@ -60,7 +65,19 @@ public class EnforcerRuleCache {
         Class<? extends AbstractEnforcerRule> ruleClass = rule.getClass();
         logger.debug("Check cache for {} with id {}", ruleClass, cacheId);
 
+        SessionData sessionData = sessionProvider.get().getRepositorySession().getData();
+
         synchronized (this) {
+
+            // sessionData.computeIfAbsent() is available in Maven 3.9.x, so do it manually
+            Map<Class<? extends AbstractEnforcerRule>, List<String>> cache =
+                    (Map<Class<? extends AbstractEnforcerRule>, List<String>>) sessionData.get("enforcer-cache");
+
+            if (cache == null) {
+                cache = new HashMap<>();
+                sessionData.set("enforcer-cache", cache);
+            }
+
             List<String> cacheIdList = cache.computeIfAbsent(ruleClass, k -> new ArrayList<>());
             if (cacheIdList.contains(cacheId)) {
                 logger.debug("Already cached {} with id {}", ruleClass, cacheId);
@@ -71,13 +88,5 @@ public class EnforcerRuleCache {
         }
 
         return false;
-    }
-
-    @PreDestroy
-    public void cleanup() {
-        logger.debug("Enforcer rule cache - cleanup");
-        synchronized (this) {
-            cache.clear();
-        }
     }
 }

--- a/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache.java
+++ b/maven-enforcer-plugin/src/main/java/org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache.java
@@ -20,13 +20,13 @@ package org.apache.maven.plugins.enforcer.internal;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.maven.SessionScoped;
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,12 +38,16 @@ import org.slf4j.LoggerFactory;
  * @since 3.2.0
  */
 @Named
-@Singleton
+@SessionScoped
 public class EnforcerRuleCache {
 
     private final Logger logger = LoggerFactory.getLogger(EnforcerRuleCache.class);
 
     private final Map<Class<? extends AbstractEnforcerRule>, List<String>> cache = new HashMap<>();
+
+    EnforcerRuleCache() {
+        logger.debug("Enforcer rule cache - created");
+    }
 
     public boolean isCached(AbstractEnforcerRule rule) {
 
@@ -71,6 +75,7 @@ public class EnforcerRuleCache {
 
     @PreDestroy
     public void cleanup() {
+        logger.debug("Enforcer rule cache - cleanup");
         synchronized (this) {
             cache.clear();
         }


### PR DESCRIPTION
Each Maven session should have a new cache.

Singleton can be shared between executions by Maven Daemon.
