### PR TITLE
Fix handling of Java versions like 21.0.10.0.1

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/RequireJavaVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/version/RequireJavaVersion.java
@@ -98,7 +98,11 @@ public final class RequireJavaVersion extends AbstractVersionEnforcer {
 
         setCustomMessageIfNoneConfigured(detectedJdkVersion, getVersion());
 
-        enforceVersion("JDK", getVersion(), detectedJdkVersion);
+        try {
+            enforceVersion("JDK", getVersion(), new DefaultArtifactVersion(javaVersion));
+        } catch (EnforcerRuleException ex) {
+            enforceVersion("JDK", getVersion(), detectedJdkVersion);
+        }
     }
 
     /**


### PR DESCRIPTION
The pull request allows the Java version requirement to be satisfied even when the normalized Java version differs, as long as the exact version strings are equal between the expected and the actual versions.

This allows the common CI pattern

```xml
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-enforcer-plugin</artifactId>
        <version>3.6.2</version>
        <executions>
          <execution>
            <id>enforce-java</id>
            <phase>validate</phase>
            <goals>
              <goal>enforce</goal>
            </goals>
            <configuration>
              <rules>
                <requireJavaVersion>
                  <version>${java.version}</version>
                </requireJavaVersion>
              </rules>
            </configuration>
          </execution>
        </executions>
      </plugin>
```

To succeed even when the Java version normalization can't handle the specific version format. This is rather hard to test, but all existing test cases succeed, and the diff is minimal.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
