### PR TITLE
Add enforceBytecodeVersion rule based on mojohaus

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -154,6 +154,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
@@ -202,6 +202,11 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
      */
     private boolean strict = false;
 
+    /**
+     * Optimization to calculate same JAR with same options once per session, by default is enabled.
+     */
+    private boolean processOncePerSession = true;
+
     // ---
 
     /**
@@ -322,7 +327,7 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
                 (ConcurrentMap<ChecksOptions, Boolean>) session.getRepositorySession()
                         .getData()
                         .computeIfAbsent(getClass().getSimpleName(), ConcurrentHashMap::new);
-        if (performedChecks.putIfAbsent(checksOptions, Boolean.TRUE) != null) {
+        if (processOncePerSession && performedChecks.putIfAbsent(checksOptions, Boolean.TRUE) != null) {
             // we already performed checks on this file with these parameters
             return null;
         }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
@@ -18,25 +18,6 @@
  */
 package org.apache.maven.enforcer.rules.dependency;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -110,60 +91,6 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
         // Java8
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("8", 52);
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.8", 52);
-        // Java9
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("9", 53);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.9", 53);
-        // Java10
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("10", 54);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.10", 54);
-        // Java11
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("11", 55);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.11", 55);
-        // Java 12
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("12", 56);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.12", 56);
-        // Java 13
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("13", 57);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.13", 57);
-        // Java 14
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("14", 58);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.14", 58);
-        // Java 15
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("15", 59);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.15", 59);
-        // Java 16
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("16", 60);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.16", 60);
-        // Java 17
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("17", 61);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.17", 61);
-        // Java 18
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("18", 62);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.18", 62);
-        // Java 19
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("19", 63);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.19", 63);
-        // Java 20
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("20", 64);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.20", 64);
-        // Java 21
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("21", 65);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.21", 65);
-        // Java 22
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("22", 66);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.22", 66);
-        // Java 23
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("23", 67);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.23", 67);
-        // Java 24
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("24", 68);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.24", 68);
-        // Java 25
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("25", 69);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.25", 69);
-        // Java 26
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("26", 70);
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.26", 70);
     }
 
     /**

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
@@ -91,6 +91,9 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
         // Java8
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("8", 52);
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.8", 52);
+        // Java9
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("9", 53);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.9", 53);
     }
 
     /**

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
@@ -1,0 +1,613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.dependency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.AbstractStandardEnforcerRule;
+import org.apache.maven.enforcer.rules.utils.ArtifactMatcher;
+import org.apache.maven.enforcer.rules.utils.ArtifactUtils;
+import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.DependencyVisitor;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
+import org.eclipse.sisu.Priority;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Enforcer rule that will check the bytecode version of each class of each dependency.
+ *
+ * @see <a href="http://en.wikipedia.org/wiki/Java_class_file#General_layout">Java class file general layout</a>
+ * @since 3.6.3
+ */
+@Priority(10) // if both mojohaus and this one are present, this prevails
+@Named("enforceBytecodeVersion")
+public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
+    /**
+     * Default ignores when validating against jdk < 9 because <code>module-info.class</code> will always have level 1.9.
+     */
+    private static final String[] DEFAULT_CLASSES_IGNORE_BEFORE_JDK_9 = {"module-info"};
+
+    private static final Pattern MULTI_RELEASE = Pattern.compile("META-INF/versions/(\\d+)/.*");
+
+    private static final Map<String, Integer> JDK_TO_MAJOR_VERSION_NUMBER_MAPPING = new LinkedHashMap<>();
+
+    static {
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.1", 45);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.2", 46);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.3", 47);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.4", 48);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.5", 49);
+        // Java6
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.6", 50);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("6", 50);
+        // Java7
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.7", 51);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("7", 51);
+        // Java8
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("8", 52);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.8", 52);
+        // Java9
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("9", 53);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.9", 53);
+        // Java10
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("10", 54);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.10", 54);
+        // Java11
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("11", 55);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.11", 55);
+        // Java 12
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("12", 56);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.12", 56);
+        // Java 13
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("13", 57);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.13", 57);
+        // Java 14
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("14", 58);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.14", 58);
+        // Java 15
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("15", 59);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.15", 59);
+        // Java 16
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("16", 60);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.16", 60);
+        // Java 17
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("17", 61);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.17", 61);
+        // Java 18
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("18", 62);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.18", 62);
+        // Java 19
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("19", 63);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.19", 63);
+        // Java 20
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("20", 64);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.20", 64);
+        // Java 21
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("21", 65);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.21", 65);
+        // Java 22
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("22", 66);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.22", 66);
+        // Java 23
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("23", 67);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.23", 67);
+        // Java 24
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("24", 68);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.24", 68);
+        // Java 25
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("25", 69);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.25", 69);
+        // Java 26
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("26", 70);
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("1.26", 70);
+    }
+
+    /**
+     * Visible for testing.
+     */
+    static String renderVersion(int major, int minor) {
+        if (minor == 0) {
+            if (major > 52) {
+                return "JDK " + (major - 44);
+            }
+            for (Map.Entry<String, Integer> entry : JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.entrySet()) {
+                if (major == entry.getValue()) {
+                    return "JDK " + entry.getKey();
+                }
+            }
+        }
+        return major + "." + minor;
+    }
+
+    /**
+     * Visible for testing.
+     */
+    static Integer decodeMajorVersion(String version) {
+        Integer major = JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.get(version);
+        if (major == null) {
+            try {
+                major = Integer.parseInt(version);
+                major = major < 8 ? null : major + 44;
+            } catch (NumberFormatException e) {
+                // ignore, will return null
+            }
+        }
+        return major;
+    }
+
+    /**
+     * Custom message, optional. If configured, will be present on first line of the error message.
+     */
+    private String message;
+
+    /**
+     * JDK version as used for example in the maven-compiler-plugin: 8, 11 and so on. If in need of more precise
+     * configuration please see {@link #maxJavaMajorVersionNumber} and {@link #maxJavaMinorVersionNumber} Mandatory if
+     * {@link #maxJavaMajorVersionNumber} not specified.
+     */
+    private String maxJdkVersion;
+
+    /**
+     * If unsure, don't use that parameter. Better look at {@link #maxJdkVersion}. Mandatory if {@link #maxJdkVersion}
+     * is not specified. see http://en.wikipedia.org/wiki/Java_class_file#General_layout
+     */
+    private int maxJavaMajorVersionNumber = -1;
+
+    /**
+     * This parameter is here for potentially advanced use cases, but it seems like it is actually always 0.
+     *
+     * @see #maxJavaMajorVersionNumber
+     * @see <a href="https://en.wikipedia.org/wiki/Java_class_file#General_layout">Java class file general layout</a>
+     */
+    private int maxJavaMinorVersionNumber = 0;
+
+    /**
+     * Specify the excluded dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     */
+    private List<String> excludes = null;
+
+    /**
+     * Specify the included dependencies. This can be a list of artifacts in the format
+     * <code>groupId[:artifactId][:version]</code>. Any of the sections can be a wildcard
+     * by using '*' (ie group:*:1.0) <br>
+     * Includes override the exclude rules. It is meant to allow wide exclusion rules
+     * with wildcards and still allow a
+     * smaller set of includes. <br>
+     * For example, to ban all xerces except xerces-api -&gt; exclude "xerces", include "xerces:xerces-api"
+     */
+    private List<String> includes = null;
+
+    /**
+     * List of classes to fully ignore, interpreted as regular expression.
+     */
+    private List<String> ignoreClasses;
+
+    /**
+     * List of dependency scopes, to include dependencies in it. Default is to include all scopes.
+     */
+    private List<String> includedScopes;
+
+    /**
+     * List of dependency scopes, to ignore dependencies in it. Default is to not exclude any scope. Excluding
+     * scopes like {@code ["test", "provided"]} is usually right thing to do.
+     */
+    private List<String> ignoredScopes;
+
+    /**
+     * If set, will ignore optional dependencies of the project.
+     */
+    private boolean ignoreOptionals = false;
+
+    /**
+     * If set, transitive hull of project is being processed, otherwise only direct dependencies.
+     * Default is {@code true}.
+     */
+    private boolean searchTransitive = true;
+
+    /**
+     * Process module-info and Multi-Release JAR classes if {@code true}.
+     */
+    private boolean strict = false;
+
+    // ---
+
+    /**
+     * Internal: strings (regexp expressions) are collected here to ignore matched classes.
+     */
+    private final List<String> ignorableClassesPatterns = new ArrayList<>();
+
+    private final MavenSession session;
+
+    private final ResolverUtil resolverUtil;
+
+    @Inject
+    EnforceBytecodeVersion(MavenSession session, ResolverUtil resolverUtil) {
+        this.session = requireNonNull(session);
+        this.resolverUtil = requireNonNull(resolverUtil);
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        validateAndPopulateParameters();
+
+        List<Dependency> dependencies = null;
+        if (!searchTransitive) {
+            dependencies = session.getCurrentProject().getDependencyArtifacts().stream()
+                    .map(ma -> new Dependency(RepositoryUtils.toArtifact(ma), ma.getScope(), ma.isOptional()))
+                    .collect(Collectors.toList());
+        } else {
+            dependencies = dependencyGraphToList(resolverUtil.resolveTransitiveDependencies(
+                    false, true, ignoreOptionals, ignoredScopes == null ? Collections.emptyList() : ignoredScopes));
+        }
+        List<Dependency> foundExcludes = checkDependencies(filterDependencies(dependencies));
+        // if any are found, fail the check but list all of them
+        if (!foundExcludes.isEmpty()) {
+            StringBuilder buf = new StringBuilder();
+            if (message != null) {
+                buf.append(message).append("\n");
+            }
+            for (Dependency dependency : foundExcludes) {
+                buf.append("Found Banned Dependency: ")
+                        .append(ArtifactIdUtils.toId(dependency.getArtifact()))
+                        .append("\n");
+            }
+            message = buf + "Use 'mvn dependency:tree' to locate the source of the banned dependencies.";
+
+            throw new EnforcerRuleException(message);
+        }
+    }
+
+    private void validateAndPopulateParameters() throws EnforcerRuleException {
+        if (maxJdkVersion != null && maxJavaMajorVersionNumber != -1) {
+            throw new IllegalArgumentException("Only maxJdkVersion or maxJavaMajorVersionNumber "
+                    + "configuration parameters should be set. Not both.");
+        }
+        if (maxJdkVersion == null && maxJavaMajorVersionNumber == -1) {
+            throw new IllegalArgumentException(
+                    "Exactly one of maxJdkVersion or maxJavaMajorVersionNumber options should be set.");
+        }
+        if (maxJdkVersion != null) {
+            Integer needle = decodeMajorVersion(maxJdkVersion);
+            if (needle == null) {
+                throw new IllegalArgumentException(
+                        "Unknown JDK version given. Should be something like \"8\", \"11\", \"17\", \"21\" ..");
+            }
+            maxJavaMajorVersionNumber = needle;
+            if (!strict && needle < 53) {
+                getLog().debug("Ignore: module-info (target < Java 8)");
+                ignorableClassesPatterns.addAll(Arrays.asList(DEFAULT_CLASSES_IGNORE_BEFORE_JDK_9));
+            }
+        }
+        if (maxJavaMajorVersionNumber == -1) {
+            throw new EnforcerRuleException("maxJavaMajorVersionNumber must be set in the plugin configuration");
+        }
+        if (ignoreClasses != null) {
+            ignorableClassesPatterns.addAll(ignoreClasses);
+        }
+    }
+
+    private List<Dependency> checkDependencies(List<Dependency> dependencies) throws EnforcerRuleException {
+        long beforeCheck = System.currentTimeMillis();
+        List<Dependency> problematic = new ArrayList<>();
+        for (Dependency dependency : dependencies) {
+            getLog().debug("Analyzing artifact " + dependency);
+            String problem = isBadDependency(dependency);
+            if (problem != null) {
+                getLog().info(problem);
+                problematic.add(dependency);
+            }
+        }
+        getLog().debug("Bytecode version analysis took " + (System.currentTimeMillis() - beforeCheck) + " ms");
+        return problematic;
+    }
+
+    private String isBadDependency(Dependency d) throws EnforcerRuleException {
+        if (d.getArtifact() == null) {
+            return null;
+        }
+        File f = d.getArtifact().getFile();
+        getLog().debug("isBadDependency() a:" + d + " Artifact getFile():"
+                + d.getArtifact().getFile());
+        if (f == null) {
+            // This happens if someone defines dependencies instead of dependencyManagement in a pom file
+            // which packaging type is pom.
+            return null;
+        }
+        if (!f.getName().endsWith(".jar")) {
+            return null;
+        }
+        // check did we do this already?
+        ChecksOptions checksOptions = new ChecksOptions(
+                ArtifactIdUtils.toId(d.getArtifact()),
+                f,
+                ignorableClassesPatterns,
+                maxJavaMajorVersionNumber,
+                maxJavaMinorVersionNumber,
+                strict);
+
+        ConcurrentMap<ChecksOptions, Boolean> performedChecks =
+                (ConcurrentMap<ChecksOptions, Boolean>) session.getRepositorySession()
+                        .getData()
+                        .computeIfAbsent(getClass().getSimpleName(), ConcurrentHashMap::new);
+        if (performedChecks.putIfAbsent(checksOptions, Boolean.TRUE) != null) {
+            // we already performed checks on this file with these parameters
+            return null;
+        }
+
+        return performCheck(getLog(), checksOptions);
+    }
+
+    /**
+     * Input is Dependency file, and it may have been inspected already, but, in multi-module environment the configuration
+     * may be different. Hence, we create a "key" out of config and dependency path, and if already inspected, we
+     * skip on doing same job over and over again.
+     */
+    private static class ChecksOptions {
+        private final String id;
+        private final File file;
+        private final List<String> ignorableClasses;
+        private final int maxJavaMajorVersionNumber;
+        private final int maxJavaMinorVersionNumber;
+        private final boolean strict;
+
+        private ChecksOptions(
+                String id,
+                File file,
+                List<String> ignorableClasses,
+                int maxJavaMajorVersionNumber,
+                int maxJavaMinorVersionNumber,
+                boolean strict) {
+            this.id = id;
+            this.file = file;
+            this.ignorableClasses = ignorableClasses;
+            this.maxJavaMajorVersionNumber = maxJavaMajorVersionNumber;
+            this.maxJavaMinorVersionNumber = maxJavaMinorVersionNumber;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof ChecksOptions)) {
+                return false;
+            }
+            ChecksOptions that = (ChecksOptions) o;
+            return maxJavaMajorVersionNumber == that.maxJavaMajorVersionNumber
+                    && maxJavaMinorVersionNumber == that.maxJavaMinorVersionNumber
+                    && strict == that.strict
+                    && Objects.equals(id, that.id)
+                    && Objects.equals(file, that.file)
+                    && Objects.equals(ignorableClasses, that.ignorableClasses);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    id, file, ignorableClasses, maxJavaMajorVersionNumber, maxJavaMinorVersionNumber, strict);
+        }
+    }
+
+    /**
+     * Convert a wildcard into a regex.
+     *
+     * @param wildcard the wildcard to convert.
+     * @return the equivalent regex.
+     */
+    private static String asRegex(String wildcard) {
+        StringBuilder result = new StringBuilder(wildcard.length());
+        result.append('^');
+        for (int index = 0; index < wildcard.length(); index++) {
+            char character = wildcard.charAt(index);
+            switch (character) {
+                case '*':
+                    result.append(".*");
+                    break;
+                case '?':
+                    result.append(".");
+                    break;
+                case '$':
+                case '(':
+                case ')':
+                case '.':
+                case '[':
+                case '\\':
+                case ']':
+                case '^':
+                case '{':
+                case '|':
+                case '}':
+                    result.append("\\");
+                default:
+                    result.append(character);
+                    break;
+            }
+        }
+        result.append("(\\.class)?");
+        result.append('$');
+        return result.toString();
+    }
+
+    private static String performCheck(EnforcerLogger log, ChecksOptions options) throws EnforcerRuleException {
+        Predicate<String> ignorableClasses = null;
+        for (String ignorableClass : options.ignorableClasses) {
+            Pattern pattern = Pattern.compile(asRegex(ignorableClass.replace('.', '/')));
+            Predicate<String> p = s -> pattern.matcher(s).matches();
+            if (ignorableClasses == null) {
+                ignorableClasses = p;
+            } else {
+                ignorableClasses = ignorableClasses.or(p);
+            }
+        }
+        try (JarFile jarFile = new JarFile(options.file)) {
+            log.debug(options.file.getName() + " => " + options.file.getPath());
+            byte[] magicAndClassFileVersion = new byte[8];
+            for (Enumeration<JarEntry> e = jarFile.entries(); e.hasMoreElements(); ) {
+                JarEntry entry = e.nextElement();
+                if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+                    if (ignorableClasses != null && ignorableClasses.test(entry.getName())) {
+                        continue;
+                    }
+
+                    try (InputStream is = jarFile.getInputStream(entry)) {
+                        int total = magicAndClassFileVersion.length;
+                        while (total > 0) {
+                            int read =
+                                    is.read(magicAndClassFileVersion, magicAndClassFileVersion.length - total, total);
+                            if (read == -1) {
+                                throw new EOFException(options.file.toString());
+                            }
+                            total -= read;
+                        }
+                    }
+
+                    int minor = (magicAndClassFileVersion[4] << 8) + magicAndClassFileVersion[5];
+                    int major = (magicAndClassFileVersion[6] << 8) + magicAndClassFileVersion[7];
+
+                    // Assuming regex match is more expensive, verify bytecode versions first
+
+                    if ((major > options.maxJavaMajorVersionNumber)
+                            || (major == options.maxJavaMajorVersionNumber
+                                    && minor > options.maxJavaMinorVersionNumber)) {
+
+                        Matcher matcher = MULTI_RELEASE.matcher(entry.getName());
+
+                        if (!options.strict && matcher.matches()) {
+                            Integer maxExpectedMajor = decodeMajorVersion(matcher.group(1));
+
+                            if (maxExpectedMajor == null) {
+                                log.warn("Unknown bytecodeVersion for " + options.id
+                                        + " : " + entry.getName() + ": got " + maxExpectedMajor
+                                        + " class-file-version");
+                            } else if (major > maxExpectedMajor) {
+                                log.warn("Invalid bytecodeVersion for " + options.id
+                                        + " : " + entry.getName() + ": expected lower or equal to " + maxExpectedMajor
+                                        + ", but was " + major);
+                            }
+                        } else {
+                            return "Restricted to "
+                                    + renderVersion(
+                                            options.maxJavaMajorVersionNumber, options.maxJavaMinorVersionNumber)
+                                    + " yet " + options.id + " contains " + entry.getName()
+                                    + " targeted to "
+                                    + renderVersion(major, minor);
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new EnforcerRuleException("IOException while reading " + options.file, e);
+        } catch (IllegalArgumentException e) {
+            throw new EnforcerRuleException("Error while reading " + options.file, e);
+        }
+        return null;
+    }
+
+    private List<Dependency> dependencyGraphToList(DependencyNode root) {
+        ArrayList<Dependency> result = new ArrayList<>();
+        DependencyVisitor visitor = new DependencyVisitor() {
+            @Override
+            public boolean visitEnter(DependencyNode node) {
+                if (node.getDependency() != null) {
+                    result.add(node.getDependency());
+                } else {
+                    result.add(new Dependency(node.getArtifact(), null));
+                }
+                return true;
+            }
+
+            @Override
+            public boolean visitLeave(DependencyNode node) {
+                return true;
+            }
+        };
+        root.accept(new TreeDependencyVisitor(visitor));
+        return result;
+    }
+
+    private List<Dependency> filterDependencies(List<Dependency> dependencies) {
+        Predicate<Dependency> includeExcludeMatcher = d -> true;
+        if (includes != null || excludes != null) {
+            ArtifactMatcher artifactMatcher = new ArtifactMatcher(excludes, includes);
+            includeExcludeMatcher = d -> artifactMatcher.match(ArtifactUtils.toArtifact(d));
+        }
+        Predicate<Dependency> scopeMatcher = d -> true;
+        if (includedScopes != null) {
+            scopeMatcher = d -> {
+                if (includedScopes.contains(d.getScope())) {
+                    return true;
+                } else {
+                    getLog().debug("Skipping {} due to scope");
+                    return false;
+                }
+            };
+        }
+        return dependencies.stream()
+                .filter(includeExcludeMatcher.and(scopeMatcher))
+                .collect(Collectors.toList());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion.java
@@ -181,7 +181,7 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
     /**
      * List of dependency scopes, to include dependencies in it. Default is to include all scopes.
      */
-    private List<String> includedScopes;
+    private List<String> scopes;
 
     /**
      * List of dependency scopes, to ignore dependencies in it. Default is to not exclude any scope. Excluding
@@ -531,9 +531,9 @@ public class EnforceBytecodeVersion extends AbstractStandardEnforcerRule {
             includeExcludeMatcher = d -> artifactMatcher.match(ArtifactUtils.toArtifact(d));
         }
         Predicate<Dependency> scopeMatcher = d -> true;
-        if (includedScopes != null) {
+        if (scopes != null) {
             scopeMatcher = d -> {
-                if (includedScopes.contains(d.getScope())) {
+                if (scopes.contains(d.getScope())) {
                     return true;
                 } else {
                     getLog().debug("Skipping {} due to scope");

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/ResolverUtil.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/ResolverUtil.java
@@ -40,6 +40,8 @@ import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.DependencyVisitor;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
@@ -82,7 +84,7 @@ class ResolverUtil {
      * @throws EnforcerRuleException thrown if the lookup fails
      */
     DependencyNode resolveTransitiveDependenciesVerbose(List<String> excludedScopes) throws EnforcerRuleException {
-        return resolveTransitiveDependencies(true, true, excludedScopes);
+        return resolveTransitiveDependencies(true, false, true, excludedScopes);
     }
 
     /**
@@ -93,7 +95,7 @@ class ResolverUtil {
      * @throws EnforcerRuleException thrown if the lookup fails
      */
     DependencyNode resolveTransitiveDependencies() throws EnforcerRuleException {
-        return resolveTransitiveDependencies(false, true, Arrays.asList(SCOPE_TEST, SCOPE_PROVIDED));
+        return resolveTransitiveDependencies(false, false, true, Arrays.asList(SCOPE_TEST, SCOPE_PROVIDED));
     }
 
     /**
@@ -107,10 +109,16 @@ class ResolverUtil {
      */
     DependencyNode resolveTransitiveDependencies(boolean excludeOptional, List<String> excludedScopes)
             throws EnforcerRuleException {
-        return resolveTransitiveDependencies(false, excludeOptional, excludedScopes);
+        return resolveTransitiveDependencies(false, false, excludeOptional, excludedScopes);
     }
 
     DependencyNode resolveTransitiveDependencies(boolean verbose, boolean excludeOptional, List<String> excludedScopes)
+            throws EnforcerRuleException {
+        return resolveTransitiveDependencies(verbose, false, excludeOptional, excludedScopes);
+    }
+
+    DependencyNode resolveTransitiveDependencies(
+            boolean verbose, boolean resolve, boolean excludeOptional, List<String> excludedScopes)
             throws EnforcerRuleException {
 
         try {
@@ -145,11 +153,19 @@ class ResolverUtil {
                     new CollectRequest(dependencies, managedDependencies, project.getRemoteProjectRepositories());
             collectRequest.setRootArtifact(RepositoryUtils.toArtifact(project.getArtifact()));
 
-            return repositorySystem
-                    .collectDependencies(repositorySystemSession, collectRequest)
-                    .getRoot();
+            if (resolve) {
+                DependencyRequest dependencyRequest = new DependencyRequest();
+                dependencyRequest.setCollectRequest(collectRequest);
 
-        } catch (DependencyCollectionException e) {
+                return repositorySystem
+                        .resolveDependencies(repositorySystemSession, dependencyRequest)
+                        .getRoot();
+            } else {
+                return repositorySystem
+                        .collectDependencies(repositorySystemSession, collectRequest)
+                        .getRoot();
+            }
+        } catch (DependencyCollectionException | DependencyResolutionException e) {
             throw new EnforcerRuleException("Could not build dependency tree " + e.getLocalizedMessage(), e);
         }
     }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactUtils.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactUtils.java
@@ -29,6 +29,7 @@ import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 
 import static java.util.Optional.ofNullable;
@@ -40,21 +41,26 @@ import static java.util.Optional.ofNullable;
  */
 public final class ArtifactUtils {
 
+    public static Artifact toArtifact(DependencyNode node) {
+        if (node.getDependency() == null) {
+            return RepositoryUtils.toArtifact(node.getArtifact());
+        }
+        return toArtifact(node.getDependency());
+    }
+
     /**
-     * Converts {@link DependencyNode} to {@link Artifact}; in comparison
+     * Converts {@link Dependency} to {@link Artifact}; in comparison
      * to {@link RepositoryUtils#toArtifact(org.eclipse.aether.artifact.Artifact)}, this method
      * assigns {@link Artifact#getScope()} and {@link Artifact#isOptional()} based on
      * the dependency information from the node.
      *
-     * @param node {@link DependencyNode} to convert to {@link Artifact}
+     * @param dependency {@link Dependency} to convert to {@link Artifact}
      * @return target artifact
      */
-    public static Artifact toArtifact(DependencyNode node) {
-        Artifact artifact = RepositoryUtils.toArtifact(node.getArtifact());
-        ofNullable(node.getDependency()).ifPresent(dependency -> {
-            ofNullable(dependency.getScope()).ifPresent(artifact::setScope);
-            artifact.setOptional(dependency.isOptional());
-        });
+    public static Artifact toArtifact(Dependency dependency) {
+        Artifact artifact = RepositoryUtils.toArtifact(dependency.getArtifact());
+        ofNullable(dependency.getScope()).ifPresent(artifact::setScope);
+        artifact.setOptional(dependency.isOptional());
         return artifact;
     }
 

--- a/enforcer-rules/src/site/apt/enforceBytecodeVersion.apt.vm
+++ b/enforcer-rules/src/site/apt/enforceBytecodeVersion.apt.vm
@@ -1,0 +1,92 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.    
+ 
+  ------
+  Enforce Bytecode Version
+  ------
+  Baptiste Mathus
+  ------
+  Mars 2013
+  ------
+
+Enforce Bytecode Version
+
+  This rule checks the dependencies transitively and fails if any class of any dependency is having its bytecode version higher than the one specified.
+
+  The following parameters are supported by this rule:
+
+  * <<maxJdkVersion>> - the maximum target jdk version (e.g. 8, 11, 17, 21...)
+
+  * <<maxJavaMajorVersionNumber>> - an integer indicating the maximum bytecode major version number (cannot be specified if maxJdkVersion is present)
+
+  * <<maxJavaMinorVersionNumber>> - an integer indicating the maximum bytecode minor version number (cannot be specified if maxJdkVersion is present)
+
+  * <<includes>>, <<excludes>> - optional lists of artifact patterns to include or exclude ([groupId]:[artifactId]:[type]:[version] with wildcards and optional segments)
+
+  * <<ignoreClasses>> - a list of classes to ignore bytecode version problems. Wildcards can be specified using the * character.
+
+  * <<scopes>> - a list of scopes (e.g. test, provided) to include when scanning artifacts
+
+  * <<ignoredScopes>> - a list of scopes (e.g. test, provided) to ignore when scanning artifacts
+
+  * <<ignoreOptionals>> - a boolean, if <<<true>>> all dependencies which have <<<<optional>true</optional>>>> are ignored.
+
+  * <<searchTransitive>> - a boolean, specify if transitive dependencies should be searched (default) or only look at direct dependencies.
+
+  * <<strict>> - a boolean, if <<<true>>> process module-info and Multi-Release JAR classes
+
+  * <<processOncePerSession>> - a boolean (by default <<true>>), optimize and process same JAR only once per session
+
+  []
+
+Note
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>8</maxJdkVersion>
+                  <excludes>
+                    <exclude>org.jline:jline</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.dependency;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class EnforceBytecodeVersionTest {
+
+    static Stream<Arguments> renderVersion() {
+        return Stream.of(
+                arguments("44.0", 44, 0),
+                arguments("JDK 1.5", 49, 0),
+                arguments("JDK 1.7", 51, 0),
+                arguments("51.3", 51, 3),
+                arguments("JDK 8", 52, 0),
+                arguments("JDK 11", 55, 0),
+                arguments("JDK 12", 56, 0),
+                arguments("JDK 21", 65, 0),
+                arguments("JDK 26", 70, 0),
+                arguments("JDK 57", 101, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void renderVersion(String expected, int major, int minor) {
+        assertEquals(expected, EnforceBytecodeVersion.renderVersion(major, minor));
+    }
+
+    public static Stream<Arguments> decodeMajorVersion() {
+        return Stream.of(
+                arguments("1.1", 45),
+                arguments("1.2", 46),
+                arguments("1.3", 47),
+                arguments("1.4", 48),
+                arguments("1.5", 49),
+                arguments("1.6", 50),
+                arguments("1.7", 51),
+                arguments("1.8", 52),
+                arguments("8", 52),
+                arguments("1.9", 53),
+                arguments("9", 53),
+                arguments("11", 55),
+                arguments("12", 56),
+                arguments("21", 65),
+                arguments("26", 70),
+                arguments("57", 101));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void decodeMajorVersion(String version, int expectedMajor) {
+        assertEquals(expectedMajor, EnforceBytecodeVersion.decodeMajorVersion(version));
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
@@ -60,6 +60,7 @@ class EnforceBytecodeVersionTest {
                 arguments("1.7", 51),
                 arguments("1.8", 52),
                 arguments("8", 52),
+                arguments("1.9", 53),
                 arguments("9", 53),
                 arguments("11", 55),
                 arguments("12", 56),

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersionTest.java
@@ -60,7 +60,6 @@ class EnforceBytecodeVersionTest {
                 arguments("1.7", 51),
                 arguments("1.8", 52),
                 arguments("8", 52),
-                arguments("1.9", 53),
                 arguments("9", 53),
                 arguments("11", 55),
                 arguments("12", 56),

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-direct-deps/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-direct-deps/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>enforce-bytecode-version-direct-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Check only direct dependencies</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <enforceBytecodeVersion>
+                            <maxJdkVersion>1.5</maxJdkVersion>
+                            <searchTransitive>false</searchTransitive>
+                        </enforceBytecodeVersion>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-direct-deps/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-direct-deps/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File(basedir, "build.log")
+assert file.exists()
+
+String text = file.getText("utf-8")
+
+// only direct dependency
+assert text.contains('[DEBUG] Analyzing artifact junit:junit:jar')
+assert text.contains('[DEBUG] Analyzing artifact org.slf4j:slf4j-simple:jar')
+
+// no transitive dependencies
+assert !text.contains('[DEBUG] Analyzing artifact org.hamcrest:hamcrest-core:jar')
+assert !text.contains('[DEBUG] Analyzing artifact org.slf4j:slf4j-api:jar')

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluded-deps/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluded-deps/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+        <name>MOJO-1976 bytecode version excludes</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.5</maxJdkVersion>
+							<excludes>
+								<exclude>org.mindrot:jbcrypt:*:*</exclude>
+							</excludes>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mindrot</groupId>
+			<artifactId>jbcrypt</artifactId>
+			<version>0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluded-deps/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluded-deps/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert !text.contains("Found Banned Dependency")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests-nonmatch/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests-nonmatch/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests-nonmatch/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests-nonmatch/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>enforce-bytecode-version-excluding-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>MOJO-1988</description>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <enforceBytecodeVersion>
+                            <maxJdkVersion>1.4</maxJdkVersion>
+                            <ignoredScopes>
+                                <ignoredScope>test</ignoredScope>
+                            </ignoredScopes>
+                        </enforceBytecodeVersion>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-excluding-tests/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>enforce-bytecode-version-excluding-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>MOJO-1988</description>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <enforceBytecodeVersion>
+                            <maxJdkVersion>1.4</maxJdkVersion>
+                            <ignoredScopes>
+                                <ignoredScope>test</ignoredScope>
+                            </ignoredScopes>
+                        </enforceBytecodeVersion>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-ignore-optional-dependencies/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-ignore-optional-dependencies/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>enforce-bytecode-version-ignore-optional-dependencies</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>GitHub Issue #52 - ignoring optional dependencies </description>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <enforceBytecodeVersion>
+                            <maxJdkVersion>1.2</maxJdkVersion>
+                            <ignoredScopes>
+                                <!-- exclude junit/hamcrest -->
+                                <ignoredScope>test</ignoredScope>
+                            </ignoredScopes>
+                            <ignoreOptionals>true</ignoreOptionals>
+                        </enforceBytecodeVersion>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- this artifact contains classes targeting JDK 1.3 or newer -->
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>1.1</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-ignore-optional-dependencies/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-ignore-optional-dependencies/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File log = new File(basedir, 'build.log')
+ assert log.exists()
+
+// we do not log skips; check they were not analyzed instead
+assert !log.getText().contains('[DEBUG] Analyzing junit:junit:jar:4.13.2')
+assert !log.getText().contains('[DEBUG] Analyzing javax.transaction:jta:jar:1.1')

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it-runtime-scope</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Issue 57: Check runtime scope dependencies</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.2</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-runtime-scope/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-annotations:jar:3.4.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:ejb3-persistence:jar:1.0.2.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-core:jar:3.3.0.SP1")
+assert text.contains("Found Banned Dependency: javax.transaction:jta:jar:1.1")
+assert text.contains("Found Banned Dependency: org.slf4j:slf4j-api:jar:1.4.2")
+assert text.contains("Found Banned Dependency: dom4j:dom4j:jar:1.6.1")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-with-ignore/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption-with-ignore/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>enforce-java-version-rule-it</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.2</maxJdkVersion>
+              <ignoreClasses>
+                <ignoreClass>javax.transaction.*</ignoreClass>
+              </ignoreClasses>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+    <dependency>
+			<groupId>javax.transaction</groupId>
+			<artifactId>jta</artifactId>
+			<version>1.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>enforce-java-version-rule-it</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.2</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-jdkVersionOption/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-annotations:jar:3.4.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:ejb3-persistence:jar:1.0.2.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-core:jar:3.3.0.SP1")
+assert text.contains("Found Banned Dependency: javax.transaction:jta:jar:1.1")
+assert text.contains("Found Banned Dependency: org.slf4j:slf4j-api:jar:1.4.2")
+assert text.contains("Found Banned Dependency: dom4j:dom4j:jar:1.6.1")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>enforce-java-version-rule-it</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-missing-config/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Exactly one of maxJdkVersion or maxJavaMajorVersionNumber options should be set.")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>pim.pam.poum</groupId>
+  <artifactId>smoking</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>6.0</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rules>
+            <enforceBytecodeVersion>
+              <maxJdkVersion>1.8</maxJdkVersion>
+              <strict>true</strict>
+            </enforceBytecodeVersion>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8-strict/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert ! text.contains( '[INFO] Adding ignore: module-info' )
+assert text.contains( 'Found Banned Dependency: org.ow2.asm:asm:jar:6.0' )
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.8</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm</artifactId>
+			<version>6.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk8/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+File file = new File(basedir, "build.log")
+assert file.exists()
+
+String text = file.getText("utf-8")
+
+assert text.contains('[DEBUG] Ignore: module-info (target < Java 8)')

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9-strict/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9-strict/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>pim.pam.poum</groupId>
+  <artifactId>smoking</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>6.0</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rules>
+            <enforceBytecodeVersion>
+              <maxJdkVersion>1.9</maxJdkVersion>
+              <strict>true</strict>
+            </enforceBytecodeVersion>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9-strict/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9-strict/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert ! text.contains( '[INFO] Adding ignore: module-info' )
+assert ! text.contains( 'Found Banned Dependency: org.ow2.asm:asm:jar:6.0' )
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.9</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm</artifactId>
+			<version>6.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-module-info-jdk9/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert ! text.contains( '[INFO] Adding ignore: module-info' )
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-2/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-2/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.8</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-jaxb-annotations</artifactId>
+			<version>2.13.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-2/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-2/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File(basedir, "build.log")
+assert file.exists()
+
+String text = file.getText("utf-8")
+
+// old
+// assert text.contains('[DEBUG] Ignore: module-info maps to regex ^module-info(\\.class)?$')
+// new
+assert text.contains('[DEBUG] Ignore: module-info (target < Java 8)')
+assert !text.contains('[WARNING] Invalid bytecodeVersion for com.fasterxml.jackson.core:jackson-core:jar:2.13.0:runtime')

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>pim.pam.poum</groupId>
+  <artifactId>smoking</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.17.2</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <rules>
+            <enforceBytecodeVersion>
+              <maxJdkVersion>1.8</maxJdkVersion>
+              <strict>true</strict>
+            </enforceBytecodeVersion>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert ! text.contains( '[INFO] Adding ignore: module-info' )
+assert text.contains( 'Found Banned Dependency: org.apache.logging.log4j:log4j-api:jar:2.17.2' )
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.8</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.17.2</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File(basedir, "build.log")
+assert file.exists()
+
+String text = file.getText("utf-8")
+
+// old
+// assert text.contains('[DEBUG] Ignore: module-info maps to regex ^module-info(\\.class)?$')
+// new
+assert text.contains('[DEBUG] Ignore: module-info (target < Java 8)')
+assert text.contains('[DEBUG] log4j-api-2.17.2.jar => ')

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>enforce-java-version-rule-it</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.2</maxJdkVersion>
+							<maxJavaMajorVersionNumber>46</maxJavaMajorVersionNumber>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-only-one-option-allowed/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Only maxJdkVersion or maxJavaMajorVersionNumber configuration parameters should be set. Not both.")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure
+invoker.debug = false

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>enforce-java-version-rule-it</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJavaMajorVersionNumber>46</maxJavaMajorVersionNumber>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-banned-deps/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-annotations:jar:3.4.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:ejb3-persistence:jar:1.0.2.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-core:jar:3.3.0.SP1")
+assert text.contains("Found Banned Dependency: javax.transaction:jta:jar:1.1")
+assert text.contains("Found Banned Dependency: org.slf4j:slf4j-api:jar:1.4.2")
+assert text.contains("Found Banned Dependency: dom4j:dom4j:jar:1.6.1")
+assert text.contains("Restricted to JDK 1.2 yet org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA contains org/hibernate/annotations/common/AssertionFailure.class targeted to JDK 1.5")
+assert text.contains("Restricted to JDK 1.2 yet dom4j:dom4j:jar:1.6.1 contains org/dom4j/Attribute.class targeted to JDK 1.3")
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJavaMajorVersionNumber>49</maxJavaMajorVersionNumber>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/setup.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/setup.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( localRepositoryPath, "org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar" );
+if (file.exists()) {
+    file.delete();
+    file.createNewFile();
+}
+
+return true

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-with-corrupted-jar/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+def text = file.getText("utf-8");
+
+try {
+    assert text.find(/IOException while reading .*hibernate-annotations-3.4.0.GA.jar/)
+} finally {
+    File jar = new File( localRepositoryPath, "org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar" );
+    if (jar.exists()) {
+        jar.delete();
+    }
+}
+
+return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-wo-banned-deps/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-wo-banned-deps/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJavaMajorVersionNumber>49</maxJavaMajorVersionNumber>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-wo-banned-deps/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-wo-banned-deps/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert !text.contains("Found Banned Dependency: org.hibernate:hibernate-annotations:jar:3.4.0.GA")
+assert !text.contains("Found Banned Dependency: org.hibernate:ejb3-persistence:jar:1.0.2.GA")
+assert !text.contains("Found Banned Dependency: org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA")
+assert !text.contains("Found Banned Dependency: org.hibernate:hibernate-core:jar:3.3.0.SP1")
+assert !text.contains("Found Banned Dependency: javax.transaction:jta:jar:1.1")
+assert !text.contains("Found Banned Dependency: org.slf4j:slf4j-api:jar:1.4.2")
+assert !text.contains("Found Banned Dependency: dom4j:dom4j:jar:1.6.1")
+
+return true;

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,11 @@
     <javaVersion>8</javaVersion>
     <mockito.version>4.11.0</mockito.version>
     <project.build.outputTimestamp>2025-09-28T21:22:14Z</project.build.outputTimestamp>
-    <!-- the same as in Maven  -->
+    <!-- all the same as in Maven  -->
     <resolver.version>1.9.25</resolver.version>
+    <version.plexus-utils>3.6.0</version.plexus-utils>
+    <version.plexus-xml>3.0.1</version.plexus-xml>
+    <version.slf4j>1.7.36</version.slf4j>
 
     <!-- plugins used in IT, not defined in parent -->
     <version.maven-pmd-plugin>3.21.0</version.maven-pmd-plugin>
@@ -162,13 +165,13 @@
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>0.9.0.M2</version>
+        <version>1.0.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-classworlds</artifactId>
-        <version>2.5.2</version>
+        <version>2.9.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -193,6 +196,16 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.20.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${version.slf4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${version.slf4j}</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,6 @@
     <project.build.outputTimestamp>2025-09-28T21:22:14Z</project.build.outputTimestamp>
     <!-- all the same as in Maven  -->
     <resolver.version>1.9.25</resolver.version>
-    <version.plexus-utils>3.6.0</version.plexus-utils>
-    <version.plexus-xml>3.0.1</version.plexus-xml>
     <version.slf4j>1.7.36</version.slf4j>
 
     <!-- plugins used in IT, not defined in parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <project.build.outputTimestamp>2025-09-28T21:22:14Z</project.build.outputTimestamp>
     <!-- the same as in Maven  -->
     <resolver.version>1.9.27</resolver.version>
+    <version.slf4j>1.7.36</version.slf4j>
 
     <!-- plugins used in IT, not defined in parent -->
     <version.maven-pmd-plugin>3.28.0</version.maven-pmd-plugin>


### PR DESCRIPTION
This rule is very often used, and does not require anything special like new dependency, hence it should be among "built in" rules.

OTOH, it had issues, for example on larger multi projects did recheck same (potentially huge) JAR over and over again. It is now altered to not repeat same check (same options against same file) within same session.

This rule is 100% drop-in replacement for old uses (ITs are unmodified and just copied over), moreover rule itself has set priority that if enforce plugin gets updated with this rule, but the extra rules are present, the new rule will kick in. All the options are same as before, and rule name is unchanged as well.

Where it differs, and is reflected in ITs: is not so chatty as mojohaus one, it does not tell "skipped due scope", "skipped due regexp" etc, hence ITs are modified to simply assert for presence or absence of "[DEBUG] Analyzing GAV..." string instead.