### PR TITLE
Deps: Parent POM 48 and align deps

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/utils/ArtifactMatcher.java
@@ -189,14 +189,16 @@ public final class ArtifactMatcher {
      * @throws NullPointerException if any of the arguments is null
      */
     public ArtifactMatcher(final Collection<String> excludeStrings, final Collection<String> includeStrings) {
-        ofNullable(excludeStrings).ifPresent(excludes -> excludes.stream()
-                .filter(StringUtils::isNotEmpty)
-                .map(Pattern::new)
-                .forEach(excludePatterns::add));
-        ofNullable(includeStrings).ifPresent(includes -> includes.stream()
-                .filter(StringUtils::isNotEmpty)
-                .map(Pattern::new)
-                .forEach(includePatterns::add));
+        ofNullable(excludeStrings)
+                .ifPresent(excludes -> excludes.stream()
+                        .filter(StringUtils::isNotEmpty)
+                        .map(Pattern::new)
+                        .forEach(excludePatterns::add));
+        ofNullable(includeStrings)
+                .ifPresent(includes -> includes.stream()
+                        .filter(StringUtils::isNotEmpty)
+                        .map(Pattern::new)
+                        .forEach(includePatterns::add));
     }
 
     private boolean match(Function<Pattern, Boolean> matcher) {

--- a/pom.xml
+++ b/pom.xml
@@ -160,12 +160,6 @@
         <version>${resolver.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>1.0.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-classworlds</artifactId>
         <version>2.11.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>47</version>
+    <version>48</version>
     <relativePath />
   </parent>
   <groupId>org.apache.maven.enforcer</groupId>
@@ -83,11 +83,11 @@
     <mockito.version>4.11.0</mockito.version>
     <project.build.outputTimestamp>2025-09-28T21:22:14Z</project.build.outputTimestamp>
     <!-- the same as in Maven  -->
-    <resolver.version>1.9.25</resolver.version>
+    <resolver.version>1.9.27</resolver.version>
 
     <!-- plugins used in IT, not defined in parent -->
-    <version.maven-pmd-plugin>3.21.0</version.maven-pmd-plugin>
-    <version.maven-wrapper-plugin>3.2.0</version.maven-wrapper-plugin>
+    <version.maven-pmd-plugin>3.28.0</version.maven-pmd-plugin>
+    <version.maven-wrapper-plugin>3.3.4</version.maven-wrapper-plugin>
   </properties>
 
   <dependencyManagement>
@@ -162,13 +162,13 @@
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>0.9.0.M2</version>
+        <version>1.0.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-classworlds</artifactId>
-        <version>2.5.2</version>
+        <version>2.11.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
There were (most probably) dependabot that made
deps fall apart: Maven, Resolver and Sisu should
be upped in lockstep.
