### PR TITLE
Add enforceBytecodeVersion to rules index

### DIFF
--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -49,6 +49,8 @@ Built-In Rules
 
   * {{{./dependencyConvergence.html}dependencyConvergence}} - ensure all dependencies converge to the same version.
 
+  * {{{./enforceBytecodeVersion.html}enforceBytecodeVersion}} - enforces that dependency bytecode versions do not exceed the configured maximum.
+
   * {{{./evaluateBeanshell.html}evaluateBeanshell}} - evaluates a beanshell script.
 
   * {{{./externalRules.html}externalRules}} - evaluate rules from an external resource.


### PR DESCRIPTION
Summary:
- Add the `enforceBytecodeVersion` rule to the built-in rules index.
- Link the existing rule page from `enforcer-rules/src/site/apt/index.apt`.

Fixes #981

Verification:
- `git diff --check` (passes; local checkout reports the usual LF-to-CRLF warning)
- Confirmed `enforcer-rules/src/site/apt/enforceBytecodeVersion.apt.vm` exists and the index now references `enforceBytecodeVersion.html`

Template notes:
- This PR addresses one issue only.
- No unit tests or integration tests were run because this is a docs-only index link update.
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.

This was implemented with Codex assistance, with the final diff reviewed before posting.