### PR TITLE
Add Java module-info rules: requireExplicitModules, requireMinimalExports, banUnjustifiedOpens

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -159,6 +159,14 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- test only: generates module-info.class fixtures for the module rules; production code reads
+         module-info via java.lang.module.ModuleDescriptor (accessed reflectively, see JavaModuleInfoReader). -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.AbstractStandardEnforcerRule;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Base class for rules that inspect the {@code module-info.class} of the project's main output.
+ * Two output layouts are supported:
+ *
+ * <ul>
+ *   <li><b>Classic</b>: the descriptor sits directly in {@code ${project.build.outputDirectory}}
+ *       (one Maven project = one Java module);</li>
+ *   <li><b>Module source hierarchy</b> (Maven&nbsp;4, POM model 4.1.0): one Maven project compiles
+ *       several modules, each to its own subdirectory
+ *       {@code ${project.build.outputDirectory}/<module-name>/module-info.class}.</li>
+ * </ul>
+ *
+ * Subclasses call {@link #moduleOutputs()} and enforce a specific constraint on each returned
+ * {@link ModuleOutput}.
+ */
+abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
+
+    protected final MavenProject project;
+
+    protected AbstractModuleInfoRule(MavenProject project) {
+        this.project = project;
+    }
+
+    /** One compiled output that may form a Java module. */
+    protected static final class ModuleOutput {
+        private final File root;
+        private final JavaModuleInfo moduleInfo;
+
+        private ModuleOutput(File root, JavaModuleInfo moduleInfo) {
+            this.root = root;
+            this.moduleInfo = moduleInfo;
+        }
+
+        /** The directory the module's classes are compiled to. */
+        File root() {
+            return root;
+        }
+
+        /** The parsed module descriptor, or {@code null} if {@link #root()} has no {@code module-info.class}. */
+        JavaModuleInfo moduleInfo() {
+            return moduleInfo;
+        }
+    }
+
+    /** The directory the main classes (and any {@code module-info.class}) are compiled to. */
+    protected File outputDirectory() {
+        return new File(project.getBuild().getOutputDirectory());
+    }
+
+    /**
+     * Discover the project's module outputs.
+     *
+     * <p>If the output directory itself holds a {@code module-info.class} (classic layout), exactly
+     * that one output is returned. Otherwise, if at least one first-level subdirectory holds a
+     * {@code module-info.class} (Maven&nbsp;4 module source hierarchy), every first-level
+     * subdirectory is returned as one output each — including non-modular ones, whose
+     * {@link ModuleOutput#moduleInfo()} is {@code null}, so rules can flag them. Failing both, the
+     * output directory is returned as a single non-modular output.
+     *
+     * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
+     */
+    protected List<ModuleOutput> moduleOutputs() throws EnforcerRuleException {
+        File outputDirectory = outputDirectory();
+        JavaModuleInfo topLevel = readModuleInfo(outputDirectory);
+        if (topLevel != null) {
+            return Collections.singletonList(new ModuleOutput(outputDirectory, topLevel));
+        }
+        File[] subdirectories = outputDirectory.listFiles(File::isDirectory);
+        if (subdirectories != null) {
+            Arrays.sort(subdirectories);
+            List<ModuleOutput> outputs = new ArrayList<>();
+            boolean modular = false;
+            for (File subdirectory : subdirectories) {
+                JavaModuleInfo moduleInfo = readModuleInfo(subdirectory);
+                modular |= moduleInfo != null;
+                outputs.add(new ModuleOutput(subdirectory, moduleInfo));
+            }
+            if (modular) {
+                getLog().debug("Detected module source hierarchy layout below " + outputDirectory + " ("
+                        + outputs.size() + " module output(s))");
+                return outputs;
+            }
+        }
+        return Collections.singletonList(new ModuleOutput(outputDirectory, null));
+    }
+
+    /**
+     * Read the module descriptor of one output directory.
+     *
+     * @return the parsed {@link JavaModuleInfo}, or {@code null} if the directory has no
+     *         {@code module-info.class}
+     * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
+     */
+    private JavaModuleInfo readModuleInfo(File directory) throws EnforcerRuleException {
+        File moduleInfo = new File(directory, "module-info.class");
+        if (!moduleInfo.isFile()) {
+            getLog().debug("No module-info.class in " + directory);
+            return null;
+        }
+        try (InputStream in = Files.newInputStream(moduleInfo.toPath())) {
+            return JavaModuleInfoReader.read(in);
+        } catch (IOException e) {
+            throw new EnforcerRuleException("Failed to read " + moduleInfo + ": " + e.getMessage(), e);
+        }
+    }
+
+    /** Short rule name for log messages, e.g. {@code RequireMinimalExports}. */
+    protected String ruleName() {
+        return getClass().getSimpleName();
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -38,7 +38,7 @@ import org.apache.maven.project.MavenProject;
  * <ul>
  *   <li><b>Classic</b>: the descriptor sits directly in {@code ${project.build.outputDirectory}}
  *       (one Maven project = one Java module);</li>
- *   <li><b>Module source hierarchy</b> (Maven&nbsp;4, POM model 4.1.0): one Maven project compiles
+ *   <li><b>Module source hierarchy</b> (Maven 4, POM model 4.1.0): one Maven project compiles
  *       several modules, each to its own subdirectory
  *       {@code ${project.build.outputDirectory}/<module-name>/module-info.class}.</li>
  * </ul>
@@ -46,7 +46,7 @@ import org.apache.maven.project.MavenProject;
  * Subclasses call {@link #moduleOutputs()} and enforce a specific constraint on each returned
  * {@link ModuleOutput}.
  */
-abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
+public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
 
     protected final MavenProject project;
 
@@ -85,7 +85,7 @@ abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
      *
      * <p>If the output directory itself holds a {@code module-info.class} (classic layout), exactly
      * that one output is returned. Otherwise, if at least one first-level subdirectory holds a
-     * {@code module-info.class} (Maven&nbsp;4 module source hierarchy), every first-level
+     * {@code module-info.class} (Maven 4 module source hierarchy), every first-level
      * subdirectory is returned as one output each — including non-modular ones, whose
      * {@link ModuleOutput#moduleInfo()} is {@code null}, so rules can flag them. Failing both, the
      * output directory is returned as a single non-modular output.
@@ -137,7 +137,7 @@ abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
         }
     }
 
-    /** Short rule name for log messages, e.g. {@code RequireMinimalExports}. */
+    /** Short rule name for log messages, such as {@code RequireMinimalExports}. */
     protected String ruleName() {
         return getClass().getSimpleName();
     }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -93,7 +93,6 @@ public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRul
      * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
      */
     protected List<ModuleOutput> moduleOutputs() throws EnforcerRuleException {
-        requireJava9Runtime();
         File outputDirectory = outputDirectory();
         JavaModuleInfo topLevel = readModuleInfo(outputDirectory);
         if (topLevel != null) {
@@ -119,11 +118,12 @@ public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRul
     }
 
     /**
-     * Guard: these rules read {@code module-info.class}, which only a Java 9+ runtime can parse.
-     * Fail fast with a clear, upfront message when the build runs on Java 8, rather than surfacing the
-     * requirement indirectly (an obscure "failed to read" error, or — for {@code requireExplicitModules} —
-     * a misleading "not an explicit module"). The Enforcer plugin itself keeps its Java 8 baseline; only
-     * these Java module rules require 9+.
+     * Guard invoked once a {@code module-info.class} is known to be present in an output directory:
+     * only a Java 9+ runtime can parse it, so fail fast with a clear message on Java 8 instead of the
+     * obscure "failed to read" error that {@code ModuleDescriptor.read} would otherwise surface.
+     * Non-modular outputs never reach this guard, so the rules keep their documented behaviour there
+     * (do nothing, or — for {@code requireExplicitModules} — report the missing module). The Enforcer
+     * plugin itself keeps its Java 8 baseline; only reading a module descriptor needs 9+.
      *
      * @throws EnforcerRuleException if the runtime is Java 8 or older
      */
@@ -169,6 +169,9 @@ public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRul
             getLog().debug("No module-info.class in " + directory);
             return null;
         }
+        // A module-info.class is present but can only be read on a Java 9+ runtime: fail with a clear
+        // message here rather than letting ModuleDescriptor.read surface an obscure error on Java 8.
+        requireJava9Runtime();
         try (InputStream in = Files.newInputStream(moduleInfo.toPath())) {
             return JavaModuleInfoReader.read(in);
         } catch (IOException e) {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -93,6 +93,7 @@ public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRul
      * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
      */
     protected List<ModuleOutput> moduleOutputs() throws EnforcerRuleException {
+        requireJava9Runtime();
         File outputDirectory = outputDirectory();
         JavaModuleInfo topLevel = readModuleInfo(outputDirectory);
         if (topLevel != null) {
@@ -115,6 +116,44 @@ public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRul
             }
         }
         return Collections.singletonList(new ModuleOutput(outputDirectory, null));
+    }
+
+    /**
+     * Guard: these rules read {@code module-info.class}, which only a Java 9+ runtime can parse.
+     * Fail fast with a clear, upfront message when the build runs on Java 8, rather than surfacing the
+     * requirement indirectly (an obscure "failed to read" error, or — for {@code requireExplicitModules} —
+     * a misleading "not an explicit module"). The Enforcer plugin itself keeps its Java 8 baseline; only
+     * these Java module rules require 9+.
+     *
+     * @throws EnforcerRuleException if the runtime is Java 8 or older
+     */
+    private void requireJava9Runtime() throws EnforcerRuleException {
+        if (runtimeMajorVersion() < 9) {
+            throw new EnforcerRuleException("The " + ruleName() + " rule requires the build to run on Java 9 "
+                    + "or later; a module-info.class can only be read on a Java 9+ runtime. The current runtime is "
+                    + "Java " + System.getProperty("java.specification.version") + ". The Enforcer plugin itself "
+                    + "still supports Java 8 — only the Java module rules need 9+.");
+        }
+    }
+
+    /**
+     * The major version of the running JVM, detected in a Java 8-safe way: {@code java.specification.version}
+     * is {@code "1.8"} on Java 8 and {@code "9"}, {@code "17"}, … from Java 9 onwards.
+     */
+    private static int runtimeMajorVersion() {
+        String spec = System.getProperty("java.specification.version", "");
+        if (spec.startsWith("1.")) {
+            spec = spec.substring(2); // "1.8" -> "8"
+        }
+        int dot = spec.indexOf('.');
+        if (dot >= 0) {
+            spec = spec.substring(0, dot);
+        }
+        try {
+            return Integer.parseInt(spec);
+        } catch (NumberFormatException e) {
+            return 9; // unrecognized (newer) format: assume modern and let the read proceed
+        }
     }
 
     /**

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
@@ -48,7 +48,7 @@ public final class BanUnjustifiedOpens extends AbstractModuleInfoRule {
     }
 
     public void setAllowedOpens(List<String> allowedOpens) {
-        this.allowedOpens = allowedOpens;
+        this.allowedOpens = allowedOpens != null ? allowedOpens : new ArrayList<>();
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Bans unqualified deep-reflection access into a module. A bare {@code opens a.b.c;} (or an
+ * {@code open module}) grants every other module reflective access to a package's private members,
+ * which defeats strong encapsulation. A framework that needs reflective access should be named
+ * explicitly with a qualified {@code opens a.b.c to some.framework;}.
+ *
+ * <p>Packages that genuinely must be opened to the whole world can be listed in
+ * {@code <allowedOpens>} to pass the check.
+ */
+@Named("banUnjustifiedOpens")
+public final class BanUnjustifiedOpens extends AbstractModuleInfoRule {
+
+    /** Packages allowed to be opened unqualifiedly despite the ban. */
+    private List<String> allowedOpens = new ArrayList<>();
+
+    @Inject
+    public BanUnjustifiedOpens(MavenProject project) {
+        super(project);
+    }
+
+    public void setAllowedOpens(List<String> allowedOpens) {
+        this.allowedOpens = allowedOpens;
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        for (ModuleOutput output : moduleOutputs()) {
+            JavaModuleInfo module = output.moduleInfo();
+            if (module != null) {
+                checkModule(module);
+            }
+        }
+    }
+
+    private void checkModule(JavaModuleInfo module) throws EnforcerRuleException {
+        if (module.isOpen()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " is declared as an 'open module', opening every package for "
+                                    + "deep reflection. Declare a normal module and use qualified 'opens ... to <module>' "
+                                    + "for the packages that actually need it.");
+        }
+
+        List<String> violations = new ArrayList<>();
+        for (JavaModuleInfo.Directive open : module.opens()) {
+            if (!open.isQualified() && !allowedOpens.contains(open.packageName())) {
+                violations.add(open.packageName());
+            }
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " opens package(s) " + violations + " unqualifiedly. Use a "
+                                    + "qualified 'opens ... to <module>', or list the package in <allowedOpens>.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("BanUnjustifiedOpens[allowedOpens=%s, message=%s]", allowedOpens, getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable view of the {@code Module} attribute of a {@code module-info.class}:
+ * the module name plus its {@code requires} / {@code exports} / {@code opens} directives.
+ * Package and module names are in the source form (dot-separated).
+ */
+final class JavaModuleInfo {
+
+    private final String name;
+    private final boolean open;
+    private final List<String> requires;
+    private final List<Directive> exports;
+    private final List<Directive> opens;
+
+    JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
+        this.name = name;
+        this.open = open;
+        this.requires = Collections.unmodifiableList(requires);
+        this.exports = Collections.unmodifiableList(exports);
+        this.opens = Collections.unmodifiableList(opens);
+    }
+
+    /** The module name, e.g. {@code com.example.foo}. */
+    String name() {
+        return name;
+    }
+
+    /**
+     * {@code true} for an {@code open module}, which implicitly opens <em>all</em> its packages for
+     * deep reflection (its {@link #opens()} list is then empty).
+     */
+    boolean isOpen() {
+        return open;
+    }
+
+    /** Names of required modules. */
+    List<String> requires() {
+        return requires;
+    }
+
+    /** {@code exports} directives. */
+    List<Directive> exports() {
+        return exports;
+    }
+
+    /** {@code opens} directives. */
+    List<Directive> opens() {
+        return opens;
+    }
+
+    /** A single {@code exports}/{@code opens} directive: a package and its optional target modules. */
+    static final class Directive {
+        private final String packageName;
+        private final List<String> targets;
+
+        Directive(String packageName, List<String> targets) {
+            this.packageName = packageName;
+            this.targets = Collections.unmodifiableList(targets);
+        }
+
+        /** Exported/opened package, e.g. {@code com.example.foo.api}. */
+        String packageName() {
+            return packageName;
+        }
+
+        /** Target modules for a qualified directive; empty for an unqualified one. */
+        List<String> targets() {
+            return targets;
+        }
+
+        /** {@code true} if this is a qualified {@code exports ... to} / {@code opens ... to}. */
+        boolean isQualified() {
+            return !targets.isEmpty();
+        }
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.enforcer.rules.modules;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,12 +38,14 @@ final class JavaModuleInfo {
     JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
         this.name = name;
         this.open = open;
-        this.requires = Collections.unmodifiableList(requires);
-        this.exports = Collections.unmodifiableList(exports);
-        this.opens = Collections.unmodifiableList(opens);
+        // Defensive copies: decouple from the caller's lists so this view stays truly immutable
+        // (List.copyOf would be simpler but is Java 9+; this class compiles with --release 8).
+        this.requires = Collections.unmodifiableList(new ArrayList<>(requires));
+        this.exports = Collections.unmodifiableList(new ArrayList<>(exports));
+        this.opens = Collections.unmodifiableList(new ArrayList<>(opens));
     }
 
-    /** The module name, e.g. {@code com.example.foo}. */
+    /** The module name, such as {@code com.example.foo}. */
     String name() {
         return name;
     }
@@ -77,10 +80,10 @@ final class JavaModuleInfo {
 
         Directive(String packageName, List<String> targets) {
             this.packageName = packageName;
-            this.targets = Collections.unmodifiableList(targets);
+            this.targets = Collections.unmodifiableList(new ArrayList<>(targets));
         }
 
-        /** Exported/opened package, e.g. {@code com.example.foo.api}. */
+        /** Exported/opened package, such as {@code com.example.foo.api}. */
         String packageName() {
             return packageName;
         }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads the {@code Module} attribute of a {@code module-info.class} (name, {@code requires},
+ * {@code exports}, {@code opens}) by delegating to {@link java.lang.module.ModuleDescriptor}.
+ *
+ * <p><b>Design decision.</b> This plugin compiles with {@code --release 8}, so it cannot
+ * reference {@code java.lang.module.ModuleDescriptor} (a Java&nbsp;9 API) directly. The obvious
+ * alternative — a multi-release JAR overlay ({@code src/main/java9}) so the module-reading code
+ * could be compiled for Java&nbsp;9 — is deliberately <em>not</em> used: multi-release JAR support
+ * in Maven&nbsp;3 is incomplete and can even produce invalid JARs (cf. MNG-6892 / MNG-6293 and
+ * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven&nbsp;4 (POM model 4.1.0 +
+ * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven&nbsp;3</b>
+ * and a Java&nbsp;8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
+ * through this small wrapper class: the API is present at runtime whenever a
+ * {@code module-info.class} exists (such a project is necessarily built on Java&nbsp;9+), and the
+ * rules simply do nothing when there is no module descriptor. See {@code apache/maven-enforcer#995}.
+ */
+final class JavaModuleInfoReader {
+
+    private static final String MODULE_DESCRIPTOR = "java.lang.module.ModuleDescriptor";
+    private static final String INVALID_DESCRIPTOR = "java.lang.module.InvalidModuleDescriptorException";
+
+    private JavaModuleInfoReader() {}
+
+    /**
+     * Parse a {@code module-info.class}.
+     *
+     * @param in the class-file bytes of a {@code module-info.class}
+     * @return the parsed module info, or {@code null} if the bytes are not a valid module descriptor
+     * @throws IOException if the bytes cannot be read, or if {@code java.lang.module} is unavailable
+     *                     (i.e. running on a Java&nbsp;8 runtime)
+     */
+    static JavaModuleInfo read(InputStream in) throws IOException {
+        byte[] classFile = readAllBytes(in);
+        // ModuleDescriptor.read cannot parse a class file newer than the running JVM; without this
+        // check it would throw InvalidModuleDescriptorException and we would wrongly treat the module
+        // as "not present". Surface a clear diagnostic instead.
+        checkReadableVersion(classFile);
+        try {
+            Class<?> descriptorType = Class.forName(MODULE_DESCRIPTOR);
+            Object descriptor = descriptorType
+                    .getMethod("read", InputStream.class)
+                    .invoke(null, new ByteArrayInputStream(classFile));
+
+            String name = (String) descriptorType.getMethod("name").invoke(descriptor);
+            boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
+            List<String> requires = requireNames(descriptor, descriptorType);
+            List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
+            List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
+            return new JavaModuleInfo(name, open, requires, exports, opens);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause != null && INVALID_DESCRIPTOR.equals(cause.getClass().getName())) {
+                return null; // not a valid module-info.class
+            }
+            throw new IOException("Could not read module descriptor", cause != null ? cause : e);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new IOException(
+                    "java.lang.module is not available; reading module-info requires a Java 9+ runtime", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("Could not read module descriptor", e);
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream in) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int read;
+        while ((read = in.read(chunk)) != -1) {
+            buffer.write(chunk, 0, read);
+        }
+        return buffer.toByteArray();
+    }
+
+    /**
+     * Fail fast if the {@code module-info.class} was built for a newer Java release than the JVM
+     * running the enforcer, in which case {@code ModuleDescriptor.read} cannot parse it.
+     */
+    private static void checkReadableVersion(byte[] classFile) throws IOException {
+        if (classFile.length < 8
+                || (classFile[0] & 0xFF) != 0xCA
+                || (classFile[1] & 0xFF) != 0xFE
+                || (classFile[2] & 0xFF) != 0xBA
+                || (classFile[3] & 0xFF) != 0xBE) {
+            throw new IOException("Not a Java class file (bad magic)");
+        }
+        int major = ((classFile[6] & 0xFF) << 8) | (classFile[7] & 0xFF);
+        int runtimeMajor = runtimeClassFileMajor();
+        if (major > runtimeMajor) {
+            throw new IOException("module-info.class has class file version " + major + " (Java " + (major - 44)
+                    + "), which is newer than the JVM running the enforcer (class file version " + runtimeMajor
+                    + ", Java " + (runtimeMajor - 44) + "). Run the build on that Java release or newer.");
+        }
+    }
+
+    /** The class-file major version of the running JVM (e.g. 52 for Java&nbsp;8, 69 for Java&nbsp;25). */
+    private static int runtimeClassFileMajor() {
+        // "java.class.version" is "52.0", "61.0", "69.0", ... — available since Java 1.1.
+        String version = System.getProperty("java.class.version", "52.0");
+        int dot = version.indexOf('.');
+        return Integer.parseInt(dot >= 0 ? version.substring(0, dot) : version);
+    }
+
+    private static List<String> requireNames(Object descriptor, Class<?> descriptorType)
+            throws ReflectiveOperationException {
+        Set<?> requires = (Set<?>) descriptorType.getMethod("requires").invoke(descriptor);
+        Method name = Class.forName(MODULE_DESCRIPTOR + "$Requires").getMethod("name");
+        List<String> result = new ArrayList<String>(requires.size());
+        for (Object require : requires) {
+            result.add((String) name.invoke(require));
+        }
+        return result;
+    }
+
+    private static List<JavaModuleInfo.Directive> directives(
+            Object descriptor, Class<?> descriptorType, String accessor, String innerType)
+            throws ReflectiveOperationException {
+        Set<?> entries = (Set<?>) descriptorType.getMethod(accessor).invoke(descriptor);
+        Class<?> entryType = Class.forName(MODULE_DESCRIPTOR + "$" + innerType);
+        Method source = entryType.getMethod("source");
+        Method targets = entryType.getMethod("targets");
+        List<JavaModuleInfo.Directive> result = new ArrayList<JavaModuleInfo.Directive>(entries.size());
+        for (Object entry : entries) {
+            String pkg = (String) source.invoke(entry);
+            Set<?> to = (Set<?>) targets.invoke(entry); // empty for an unqualified directive
+            List<String> moduleTargets = new ArrayList<String>(to.size());
+            for (Object target : to) {
+                moduleTargets.add((String) target);
+            }
+            result.add(new JavaModuleInfo.Directive(pkg, moduleTargets));
+        }
+        return result;
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -138,6 +140,8 @@ final class JavaModuleInfoReader {
         for (Object require : requires) {
             result.add((String) name.invoke(require));
         }
+        // ModuleDescriptor#requires() is a Set: sort for stable diagnostics across JDKs
+        Collections.sort(result);
         return result;
     }
 
@@ -156,8 +160,11 @@ final class JavaModuleInfoReader {
             for (Object target : to) {
                 moduleTargets.add((String) target);
             }
+            // targets and directives come from Sets: sort for stable diagnostics across JDKs
+            Collections.sort(moduleTargets);
             result.add(new JavaModuleInfo.Directive(pkg, moduleTargets));
         }
+        result.sort(Comparator.comparing(JavaModuleInfo.Directive::packageName));
         return result;
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -35,15 +35,15 @@ import java.util.Set;
  * {@code exports}, {@code opens}) by delegating to {@link java.lang.module.ModuleDescriptor}.
  *
  * <p><b>Design decision.</b> This plugin compiles with {@code --release 8}, so it cannot
- * reference {@code java.lang.module.ModuleDescriptor} (a Java&nbsp;9 API) directly. The obvious
+ * reference {@code java.lang.module.ModuleDescriptor} (a Java 9 API) directly. The obvious
  * alternative — a multi-release JAR overlay ({@code src/main/java9}) so the module-reading code
- * could be compiled for Java&nbsp;9 — is deliberately <em>not</em> used: multi-release JAR support
- * in Maven&nbsp;3 is incomplete and can even produce invalid JARs (cf. MNG-6892 / MNG-6293 and
- * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven&nbsp;4 (POM model 4.1.0 +
- * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven&nbsp;3</b>
- * and a Java&nbsp;8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
+ * could be compiled for Java 9 — is deliberately <em>not</em> used: multi-release JAR support
+ * in Maven 3 is incomplete and can even produce invalid JARs (see MNG-6892 / MNG-6293 and
+ * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven 4 (POM model 4.1.0 +
+ * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven 3</b>
+ * and a Java 8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
  * through this small wrapper class: the API is present at runtime whenever a
- * {@code module-info.class} exists (such a project is necessarily built on Java&nbsp;9+), and the
+ * {@code module-info.class} exists (such a project is necessarily built on Java 9+), and the
  * rules simply do nothing when there is no module descriptor. See {@code apache/maven-enforcer#995}.
  */
 final class JavaModuleInfoReader {
@@ -59,7 +59,7 @@ final class JavaModuleInfoReader {
      * @param in the class-file bytes of a {@code module-info.class}
      * @return the parsed module info, or {@code null} if the bytes are not a valid module descriptor
      * @throws IOException if the bytes cannot be read, or if {@code java.lang.module} is unavailable
-     *                     (i.e. running on a Java&nbsp;8 runtime)
+     *                     because the enforcer is running on a Java 8 runtime
      */
     static JavaModuleInfo read(InputStream in) throws IOException {
         byte[] classFile = readAllBytes(in);
@@ -93,6 +93,8 @@ final class JavaModuleInfoReader {
         }
     }
 
+    // Hand-rolled drain: InputStream.readAllBytes() would do this in one call but is Java 9+,
+    // and this class compiles with --release 8 (see the class javadoc).
     private static byte[] readAllBytes(InputStream in) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         byte[] chunk = new byte[8192];
@@ -113,7 +115,7 @@ final class JavaModuleInfoReader {
                 || (classFile[1] & 0xFF) != 0xFE
                 || (classFile[2] & 0xFF) != 0xBA
                 || (classFile[3] & 0xFF) != 0xBE) {
-            throw new IOException("Not a Java class file (bad magic)");
+            throw new IOException("Not a Java class file (bad magic number)");
         }
         int major = ((classFile[6] & 0xFF) << 8) | (classFile[7] & 0xFF);
         int runtimeMajor = runtimeClassFileMajor();
@@ -124,7 +126,7 @@ final class JavaModuleInfoReader {
         }
     }
 
-    /** The class-file major version of the running JVM (e.g. 52 for Java&nbsp;8, 69 for Java&nbsp;25). */
+    /** The class-file major version of the running JVM (such as 52 for Java 8, 69 for Java 25). */
     private static int runtimeClassFileMajor() {
         // "java.class.version" is "52.0", "61.0", "69.0", ... — available since Java 1.1.
         String version = System.getProperty("java.class.version", "52.0");

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Requires that a project with compiled classes is an <em>explicit</em> Java module, i.e. that its
+ * main output contains a {@code module-info.class}. This prevents a modular application from silently
+ * consuming a dependency as an <em>automatic module</em> (a plain JAR placed on the module path),
+ * whose auto-derived name and "exports everything" semantics are unstable across releases.
+ *
+ * <p>The rule does nothing for projects that compile no classes (e.g. {@code pom} aggregators or a
+ * module that only carries resources), so it can be enabled ecosystem-wide without special-casing.
+ * In a Maven&nbsp;4 module source hierarchy every per-module output directory is checked.
+ */
+@Named("requireExplicitModules")
+public final class RequireExplicitModules extends AbstractModuleInfoRule {
+
+    @Inject
+    public RequireExplicitModules(MavenProject project) {
+        super(project);
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        List<String> violations = new ArrayList<>();
+        for (ModuleOutput output : moduleOutputs()) {
+            if (output.moduleInfo() != null) {
+                continue;
+            }
+            if (!hasCompiledClasses(output.root())) {
+                getLog().debug("No compiled classes in " + output.root() + "; skipping " + ruleName());
+                continue;
+            }
+            violations.add(output.root().getPath());
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Project '" + project.getArtifactId() + "' is not an explicit Java module: no "
+                                    + "module-info.class in " + String.join(", ", violations)
+                                    + ". Add a module-info.java so the "
+                                    + "artifact is a named module and never resolves as an automatic module.");
+        }
+    }
+
+    /** {@code true} if the output directory holds at least one compiled class other than the module descriptor. */
+    private static boolean hasCompiledClasses(File outputDirectory) throws EnforcerRuleException {
+        Path root = outputDirectory.toPath();
+        if (!Files.isDirectory(root)) {
+            return false;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .anyMatch(name -> name.endsWith(".class") && !name.equals("module-info.class"));
+        } catch (UncheckedIOException | IOException e) {
+            throw new EnforcerRuleException("Failed to scan " + outputDirectory + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RequireExplicitModules[message=%s]", getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
@@ -34,14 +34,14 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.project.MavenProject;
 
 /**
- * Requires that a project with compiled classes is an <em>explicit</em> Java module, i.e. that its
- * main output contains a {@code module-info.class}. This prevents a modular application from silently
- * consuming a dependency as an <em>automatic module</em> (a plain JAR placed on the module path),
- * whose auto-derived name and "exports everything" semantics are unstable across releases.
+ * Requires that a project with compiled classes is an <em>explicit</em> Java module. Its main output
+ * must contain a {@code module-info.class}. This prevents a modular application from silently consuming
+ * a dependency as an <em>automatic module</em> (a plain JAR placed on the module path). Such a module's
+ * auto-derived name and "exports everything" semantics are unstable across releases.
  *
- * <p>The rule does nothing for projects that compile no classes (e.g. {@code pom} aggregators or a
+ * <p>The rule does nothing for projects that compile no classes (such as {@code pom} aggregators or a
  * module that only carries resources), so it can be enabled ecosystem-wide without special-casing.
- * In a Maven&nbsp;4 module source hierarchy every per-module output directory is checked.
+ * In a Maven 4 module source hierarchy every per-module output directory is checked.
  */
 @Named("requireExplicitModules")
 public final class RequireExplicitModules extends AbstractModuleInfoRule {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -60,7 +60,7 @@ public final class RequireMinimalExports extends AbstractModuleInfoRule {
     }
 
     public void setAllowedExports(List<String> allowedExports) {
-        this.allowedExports = allowedExports;
+        this.allowedExports = allowedExports != null ? allowedExports : new ArrayList<>();
     }
 
     public void setIgnoreQualifiedExports(boolean ignoreQualifiedExports) {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Keeps a module's public surface minimal by banning {@code exports} of packages that are meant to be
+ * internal. By default any package whose name has an {@code internal} or {@code impl} segment (e.g.
+ * {@code com.example.foo.internal} or {@code com.example.impl.util}) must not be exported; the set is
+ * configurable through {@code <internalPackagePattern>}.
+ *
+ * <p>Qualified exports ({@code exports a.b.c to some.friend;}) are ignored by default, because naming
+ * the consumer is a deliberate, reviewable decision; set {@code <ignoreQualifiedExports>false</ignoreQualifiedExports>}
+ * to check them too. Individual packages can be whitelisted through {@code <allowedExports>}.
+ */
+@Named("requireMinimalExports")
+public final class RequireMinimalExports extends AbstractModuleInfoRule {
+
+    /** Regex matching packages considered non-API; a match that is exported fails the build. */
+    private String internalPackagePattern = ".*\\.(internal|impl)(\\..*)?";
+
+    /** Packages exempt from the check even if they match {@link #internalPackagePattern}. */
+    private List<String> allowedExports = new ArrayList<>();
+
+    /** When {@code true} (default), only unqualified {@code exports} are checked. */
+    private boolean ignoreQualifiedExports = true;
+
+    @Inject
+    public RequireMinimalExports(MavenProject project) {
+        super(project);
+    }
+
+    public void setInternalPackagePattern(String internalPackagePattern) {
+        this.internalPackagePattern = internalPackagePattern;
+    }
+
+    public void setAllowedExports(List<String> allowedExports) {
+        this.allowedExports = allowedExports;
+    }
+
+    public void setIgnoreQualifiedExports(boolean ignoreQualifiedExports) {
+        this.ignoreQualifiedExports = ignoreQualifiedExports;
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        Pattern internal = Pattern.compile(internalPackagePattern);
+        for (ModuleOutput output : moduleOutputs()) {
+            JavaModuleInfo module = output.moduleInfo();
+            if (module == null) {
+                continue;
+            }
+            checkModule(module, internal);
+        }
+    }
+
+    private void checkModule(JavaModuleInfo module, Pattern internal) throws EnforcerRuleException {
+        List<String> violations = new ArrayList<>();
+        for (JavaModuleInfo.Directive export : module.exports()) {
+            if (ignoreQualifiedExports && export.isQualified()) {
+                continue;
+            }
+            String packageName = export.packageName();
+            if (!allowedExports.contains(packageName)
+                    && internal.matcher(packageName).matches()) {
+                violations.add(packageName);
+            }
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " exports internal package(s) " + violations + " matching '"
+                                    + internalPackagePattern
+                                    + "'. Keep exports to public API packages, or whitelist them "
+                                    + "in <allowedExports>.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "RequireMinimalExports[internalPackagePattern=%s, ignoreQualifiedExports=%b, allowedExports=%s, message=%s]",
+                internalPackagePattern, ignoreQualifiedExports, allowedExports, getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -30,7 +30,7 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Keeps a module's public surface minimal by banning {@code exports} of packages that are meant to be
- * internal. By default any package whose name has an {@code internal} or {@code impl} segment (e.g.
+ * internal. By default any package whose name has an {@code internal} or {@code impl} segment (such as
  * {@code com.example.foo.internal} or {@code com.example.impl.util}) must not be exported; the set is
  * configurable through {@code <internalPackagePattern>}.
  *

--- a/enforcer-rules/src/site/apt/banUnjustifiedOpens.apt.vm
+++ b/enforcer-rules/src/site/apt/banUnjustifiedOpens.apt.vm
@@ -1,0 +1,89 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Ban Unjustified Opens
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Ban Unjustified Opens
+
+  This rule bans unqualified deep-reflection access into a Java module. A bare <<<opens a.b.c;>>> (or an
+  <<<open module>>>) grants <every> other module reflective access to a package's private members, which defeats
+  strong encapsulation. A framework that needs reflective access should be named explicitly with a qualified
+  <<<opens a.b.c to some.framework;>>>.
+
+  Packages that genuinely must be opened to the whole world can be listed in <<<allowedOpens>>> to pass the check.
+  The rule does nothing for non-modular projects (no <<<module-info.class>>>).
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<allowedOpens>> - a list of package names that are allowed to be opened unqualifiedly despite the ban.
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-unjustified-opens</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banUnjustifiedOpens>
+                  <allowedOpens>
+                    <allowedOpen>com.example.foo.dto</allowedOpen>
+                  </allowedOpens>
+                </banUnjustifiedOpens>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -47,6 +47,8 @@ Built-In Rules
 
   * {{{./banTransitiveDependencies.html}banTransitiveDependencies}} - enforces that project doesn't have transitive dependencies.
 
+  * {{{./banUnjustifiedOpens.html}banUnjustifiedOpens}} - bans unqualified <<<opens>>> (and <<<open module>>>) in a Java module.
+
   * {{{./dependencyConvergence.html}dependencyConvergence}} - ensure all dependencies converge to the same version.
 
   * {{{./enforceBytecodeVersion.html}enforceBytecodeVersion}} - enforces that dependency bytecode versions do not exceed the configured maximum.
@@ -63,6 +65,8 @@ Built-In Rules
 
   * {{{./requireExplicitDependencyScope.html}requireExplicitDependencyScope}} - enforces that all dependencies have an explicit scope.
 
+  * {{{./requireExplicitModules.html}requireExplicitModules}} - enforces that a project with compiled classes is an explicit Java module.
+
   * {{{./requireFileChecksum.html}requireFileChecksum}} - enforces that the specified file has a certain checksum.
   
   * {{{./requireFilesDontExist.html}requireFilesDontExist}} - enforces that the list of files does not exist.
@@ -78,6 +82,8 @@ Built-In Rules
   * {{{./requireMatchingCoordinates.html}requireMatchingCoordinates}} - enforces specific group ID and/or artifact ID patterns.
 
   * {{{./requireMavenVersion.html}requireMavenVersion}} - enforces the Maven version.
+
+  * {{{./requireMinimalExports.html}requireMinimalExports}} - enforces that a Java module does not export internal packages.
 
   * {{{./requireNoRepositories.html}requireNoRepositories}} - enforces to not include repositories.
 

--- a/enforcer-rules/src/site/apt/requireExplicitModules.apt.vm
+++ b/enforcer-rules/src/site/apt/requireExplicitModules.apt.vm
@@ -1,0 +1,83 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Require Explicit Modules
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Require Explicit Modules
+
+  This rule requires that a project which compiles classes is an <explicit> Java module, i.e. that its main
+  output contains a <<<module-info.class>>>. This prevents a modular application from silently consuming the
+  artifact as an <automatic module> (a plain JAR placed on the module path), whose auto-derived name and
+  "exports everything" semantics are unstable across releases.
+
+  The rule does nothing for projects that compile no classes (e.g. <<<pom>>> aggregators, or a module that only
+  carries resources), so it can be enabled across a whole build without special-casing.
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-explicit-modules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireExplicitModules/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/requireMinimalExports.apt.vm
+++ b/enforcer-rules/src/site/apt/requireMinimalExports.apt.vm
@@ -1,0 +1,95 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Require Minimal Exports
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Require Minimal Exports
+
+  This rule keeps a Java module's public surface minimal by banning <<<exports>>> of packages that are meant to be
+  internal. By default any package whose name has an <<<internal>>> or <<<impl>>> segment (e.g.
+  <<<com.example.foo.internal>>> or <<<com.example.impl.util>>>) must not be exported.
+
+  Qualified exports (<<<exports a.b.c to some.friend;>>>) are ignored by default, because naming the consumer is a
+  deliberate, reviewable decision. The rule does nothing for non-modular projects (no <<<module-info.class>>>).
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<internalPackagePattern>> - a regular expression matching packages considered non-API. An exported package
+     that matches fails the build. Default is <<<.*\\.(internal|impl)(\\..*)?>>>.
+
+   * <<allowedExports>> - a list of package names that are exempt from the check even if they match
+     <<<internalPackagePattern>>>.
+
+   * <<ignoreQualifiedExports>> - if <<<true>>> (default) only unqualified <<<exports>>> are checked; set to
+     <<<false>>> to also check qualified <<<exports ... to>>> directives.
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-minimal-exports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireMinimalExports>
+                  <allowedExports>
+                    <allowedExport>com.example.foo.internal.api</allowedExport>
+                  </allowedExports>
+                </requireMinimalExports>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/markdown/banUnjustifiedOpens.md.vm
+++ b/enforcer-rules/src/site/markdown/banUnjustifiedOpens.md.vm
@@ -1,0 +1,79 @@
+---
+title: Ban Unjustified Opens
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Ban Unjustified Opens
+
+This rule bans unqualified deep-reflection access into a Java module. A bare `opens a.b.c;` (or an `open module`) grants *every* other module reflective access to a package's private members, which defeats strong encapsulation. A framework that needs reflective access should be named explicitly with a qualified `opens a.b.c to some.framework;`.
+
+Packages that genuinely must be opened to the whole world can be listed in `allowedOpens` to pass the check. The rule does nothing for non-modular projects (no `module-info.class`).
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **allowedOpens** - a list of package names that are allowed to be opened unqualifiedly despite the ban.
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-unjustified-opens</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banUnjustifiedOpens>
+                  <allowedOpens>
+                    <allowedOpen>com.example.foo.dto</allowedOpen>
+                  </allowedOpens>
+                </banUnjustifiedOpens>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/site/markdown/index.md
+++ b/enforcer-rules/src/site/markdown/index.md
@@ -38,6 +38,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [bannedPlugins](./bannedPlugins.html) - enforces that specific plugins aren't included in the build.
 - [bannedRepositories](./bannedRepositories.html) - enforces to not include banned repositories.
 - [banTransitiveDependencies](./banTransitiveDependencies.html) - enforces that project doesn't have transitive dependencies.
+- [banUnjustifiedOpens](./banUnjustifiedOpens.html) - bans unqualified `opens` (and `open module`) in a Java module.
 - [dependencyConvergence](./dependencyConvergence.html) - ensure all dependencies converge to the same version.
 - [enforceBytecodeVersion](./enforceBytecodeVersion.html) - enforces that dependency bytecode versions do not exceed the configured maximum.
 - [evaluateBeanshell](./evaluateBeanshell.html) - evaluates a beanshell script.
@@ -46,6 +47,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [requireActiveProfile](./requireActiveProfile.html) - enforces one or more active profiles.
 - [requireEnvironmentVariable](./requireEnvironmentVariable.html) - enforces the existence of an environment variable.
 - [requireExplicitDependencyScope](./requireExplicitDependencyScope.html) - enforces that all dependencies have an explicit scope.
+- [requireExplicitModules](./requireExplicitModules.html) - enforces that a project with compiled classes is an explicit Java module.
 - [requireFileChecksum](./requireFileChecksum.html) - enforces that the specified file has a certain checksum.
 - [requireFilesDontExist](./requireFilesDontExist.html) - enforces that the list of files does not exist.
 - [requireFilesExist](./requireFilesExist.html) - enforces that the list of files does exist.
@@ -54,6 +56,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [requireJavaVersion](./requireJavaVersion.html) - enforces the JDK version.
 - [requireMatchingCoordinates](./requireMatchingCoordinates.html) - enforces specific group ID and/or artifact ID patterns.
 - [requireMavenVersion](./requireMavenVersion.html) - enforces the Maven version.
+- [requireMinimalExports](./requireMinimalExports.html) - enforces that a Java module does not export internal packages.
 - [requireNoRepositories](./requireNoRepositories.html) - enforces to not include repositories.
 - [requireOS](./requireOS.html) - enforces the OS / CPU Architecture.
 - [requirePluginVersions](./requirePluginVersions.html) - enforces that all plugins have a specified version.

--- a/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
+++ b/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
@@ -1,0 +1,73 @@
+---
+title: Require Explicit Modules
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Require Explicit Modules
+
+This rule requires that a project which compiles classes is an *explicit* Java module, i.e. that its main output contains a `module-info.class`. This prevents a modular application from silently consuming the artifact as an *automatic module* (a plain JAR placed on the module path), whose auto-derived name and "exports everything" semantics are unstable across releases.
+
+The rule does nothing for projects that compile no classes (e.g. `pom` aggregators, or a module that only carries resources), so it can be enabled across a whole build without special-casing.
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-explicit-modules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireExplicitModules/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
+++ b/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
@@ -26,9 +26,9 @@ under the License.
 
 # Require Explicit Modules
 
-This rule requires that a project which compiles classes is an *explicit* Java module, i.e. that its main output contains a `module-info.class`. This prevents a modular application from silently consuming the artifact as an *automatic module* (a plain JAR placed on the module path), whose auto-derived name and "exports everything" semantics are unstable across releases.
+This rule requires that a project which compiles classes is an *explicit* Java module. Its main output must contain a `module-info.class`. This prevents a modular application from silently consuming the artifact as an *automatic module* (a plain JAR placed on the module path), whose auto-derived name and "exports everything" semantics are unstable across releases.
 
-The rule does nothing for projects that compile no classes (e.g. `pom` aggregators, or a module that only carries resources), so it can be enabled across a whole build without special-casing.
+The rule does nothing for projects that compile no classes (for example `pom` aggregators, or a module that only carries resources), so it can be enabled across a whole build without special-casing.
 
 ## Reading the module descriptor
 

--- a/enforcer-rules/src/site/markdown/requireMinimalExports.md.vm
+++ b/enforcer-rules/src/site/markdown/requireMinimalExports.md.vm
@@ -1,0 +1,83 @@
+---
+title: Require Minimal Exports
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Require Minimal Exports
+
+This rule keeps a Java module's public surface minimal by banning `exports` of packages that are meant to be internal. By default any package whose name has an `internal` or `impl` segment (e.g. `com.example.foo.internal` or `com.example.impl.util`) must not be exported.
+
+Qualified exports (`exports a.b.c to some.friend;`) are ignored by default, because naming the consumer is a deliberate, reviewable decision. The rule does nothing for non-modular projects (no `module-info.class`).
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **internalPackagePattern** - a regular expression matching packages considered non-API. An exported package that matches fails the build. Default is `.*\.(internal|impl)(\..*)?`.
+
+- **allowedExports** - a list of package names that are exempt from the check even if they match `internalPackagePattern`.
+
+- **ignoreQualifiedExports** - if `true` (default) only unqualified `exports` are checked; set to `false` to also check qualified `exports ... to` directives.
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-minimal-exports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireMinimalExports>
+                  <allowedExports>
+                    <allowedExport>com.example.foo.internal.api</allowedExport>
+                  </allowedExports>
+                </requireMinimalExports>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpensTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpensTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class BanUnjustifiedOpensTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private BanUnjustifiedOpens rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new BanUnjustifiedOpens(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void qualifiedOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.fasterxml.jackson.databind")
+                .opens("com.example.foo.dto", "com.fasterxml.jackson.databind")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void unqualifiedOpensFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .opens("com.example.foo.dto")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.foo.dto"), e.getMessage());
+    }
+
+    @Test
+    void whitelistedUnqualifiedOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .opens("com.example.foo.dto")
+                .writeTo(outputDirectory);
+        rule.setAllowedOpens(Arrays.asList("com.example.foo.dto"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anOpenModuleFails() throws Exception {
+        ModuleInfoFixtures.openModule("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("open module"), e.getMessage());
+    }
+
+    @Test
+    void aModuleWithoutOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aNonModularProjectPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anUnqualifiedOpensInAModuleSourceHierarchyFails() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.cli")
+                .opens("com.example.cli")
+                .writeTo(new File(outputDirectory, "com.example.cli"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.cli"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReaderTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReaderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class JavaModuleInfoReaderTest {
+
+    /** Build a real {@code module-info.class} with ASM (test scope only). */
+    private static byte[] moduleInfo() {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        ModuleVisitor mv = cw.visitModule("com.example.foo", 0, null);
+        mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+        mv.visitRequire("com.example.bar", 0, null);
+        mv.visitExport("com/example/foo/api", 0); // unqualified
+        mv.visitExport("com/example/foo/internal", 0, "com.example.bar"); // qualified
+        mv.visitOpen("com/example/foo/impl", 0);
+        mv.visitEnd();
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    private static List<String> packages(List<JavaModuleInfo.Directive> directives) {
+        List<String> names = new ArrayList<String>();
+        for (JavaModuleInfo.Directive d : directives) {
+            names.add(d.packageName());
+        }
+        return names;
+    }
+
+    @Test
+    void readsModuleNameRequiresExportsAndOpens() throws Exception {
+        JavaModuleInfo m = JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()));
+
+        assertNotNull(m);
+        assertEquals("com.example.foo", m.name());
+
+        assertTrue(m.requires().contains("java.base"));
+        assertTrue(m.requires().contains("com.example.bar"));
+
+        List<String> exported = packages(m.exports());
+        assertTrue(exported.contains("com.example.foo.api"), "expected unqualified export");
+        assertTrue(exported.contains("com.example.foo.internal"), "expected qualified export");
+
+        assertEquals(1, m.opens().size());
+        assertEquals("com.example.foo.impl", m.opens().get(0).packageName());
+    }
+
+    @Test
+    void distinguishesQualifiedFromUnqualifiedExports() throws Exception {
+        JavaModuleInfo m = JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()));
+
+        for (JavaModuleInfo.Directive d : m.exports()) {
+            if (d.packageName().equals("com.example.foo.api")) {
+                assertTrue(!d.isQualified(), "api export must be unqualified");
+            } else if (d.packageName().equals("com.example.foo.internal")) {
+                assertTrue(d.isQualified(), "internal export must be qualified");
+                assertEquals("com.example.bar", d.targets().get(0));
+            }
+        }
+    }
+
+    @Test
+    void returnsNullForPlainClassWithoutModuleAttribute() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "com/example/Plain", null, "java/lang/Object", null);
+        cw.visitEnd();
+        assertNull(JavaModuleInfoReader.read(new ByteArrayInputStream(cw.toByteArray())));
+    }
+
+    @Test
+    void readsTheOpenModuleFlag() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        ModuleVisitor mv = cw.visitModule("com.example.foo", Opcodes.ACC_OPEN, null);
+        mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        JavaModuleInfo open = JavaModuleInfoReader.read(new ByteArrayInputStream(cw.toByteArray()));
+        assertNotNull(open);
+        assertTrue(open.isOpen(), "expected an open module");
+
+        assertFalse(JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()))
+                .isOpen());
+    }
+
+    @Test
+    void failsClearlyForAClassFileNewerThanTheRuntime() {
+        byte[] classFile = moduleInfo();
+        // bump the class-file major version to one beyond this JVM so ModuleDescriptor.read cannot parse it
+        int runtimeMajor =
+                Integer.parseInt(System.getProperty("java.class.version").split("\\.")[0]);
+        int tooNew = runtimeMajor + 1;
+        classFile[6] = (byte) ((tooNew >> 8) & 0xFF);
+        classFile[7] = (byte) (tooNew & 0xFF);
+
+        IOException e =
+                assertThrows(IOException.class, () -> JavaModuleInfoReader.read(new ByteArrayInputStream(classFile)));
+        assertTrue(e.getMessage().contains("newer than the JVM"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Test-only helper that generates real {@code module-info.class} fixtures with ASM and writes them
+ * (plus optional dummy classes) into an output directory, so the module rules can be exercised against
+ * a {@code project.build.outputDirectory} exactly as they see it at build time.
+ */
+final class ModuleInfoFixtures {
+
+    private ModuleInfoFixtures() {}
+
+    static Builder module(String name) {
+        return new Builder(name, false);
+    }
+
+    static Builder openModule(String name) {
+        return new Builder(name, true);
+    }
+
+    /** Write an arbitrary (empty) compiled class so an output directory looks non-empty to a rule. */
+    static void writeDummyClass(File outputDirectory, String binaryName) throws IOException {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
+        cw.visitEnd();
+        Files.createDirectories(outputDirectory.toPath());
+        Files.write(new File(outputDirectory, binaryName + ".class").toPath(), cw.toByteArray());
+    }
+
+    static final class Builder {
+        private final String name;
+        private final boolean open;
+        private final List<String> requires = new ArrayList<>();
+        private final List<Directive> exports = new ArrayList<>();
+        private final List<Directive> opens = new ArrayList<>();
+
+        private Builder(String name, boolean open) {
+            this.name = name;
+            this.open = open;
+        }
+
+        Builder requires(String module) {
+            requires.add(module);
+            return this;
+        }
+
+        Builder exports(String packageName, String... targets) {
+            exports.add(new Directive(packageName, targets));
+            return this;
+        }
+
+        Builder opens(String packageName, String... targets) {
+            opens.add(new Directive(packageName, targets));
+            return this;
+        }
+
+        byte[] toBytes() {
+            ClassWriter cw = new ClassWriter(0);
+            cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+            ModuleVisitor mv = cw.visitModule(name, open ? Opcodes.ACC_OPEN : 0, null);
+            mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+            for (String module : requires) {
+                mv.visitRequire(module, 0, null);
+            }
+            for (Directive export : exports) {
+                mv.visitExport(export.internalName(), 0, export.targetsOrNull());
+            }
+            for (Directive open : opens) {
+                mv.visitOpen(open.internalName(), 0, open.targetsOrNull());
+            }
+            mv.visitEnd();
+            cw.visitEnd();
+            return cw.toByteArray();
+        }
+
+        /** Write {@code module-info.class} into {@code outputDirectory} and return that directory. */
+        File writeTo(File outputDirectory) throws IOException {
+            Files.createDirectories(outputDirectory.toPath());
+            Files.write(new File(outputDirectory, "module-info.class").toPath(), toBytes());
+            return outputDirectory;
+        }
+    }
+
+    private static final class Directive {
+        private final String packageName;
+        private final String[] targets;
+
+        private Directive(String packageName, String[] targets) {
+            this.packageName = packageName;
+            this.targets = targets;
+        }
+
+        String internalName() {
+            return packageName.replace('.', '/');
+        }
+
+        /** ASM treats {@code null} (not an empty array) as an unqualified directive. */
+        String[] targetsOrNull() {
+            return targets.length == 0 ? null : targets;
+        }
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -50,8 +50,9 @@ final class ModuleInfoFixtures {
         ClassWriter cw = new ClassWriter(0);
         cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
         cw.visitEnd();
-        Files.createDirectories(outputDirectory.toPath());
-        Files.write(new File(outputDirectory, binaryName + ".class").toPath(), cw.toByteArray());
+        File classFile = new File(outputDirectory, binaryName.replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), cw.toByteArray());
     }
 
     static final class Builder {

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -47,12 +47,13 @@ final class ModuleInfoFixtures {
 
     /** Write an arbitrary (empty) compiled class so an output directory looks non-empty to a rule. */
     static void writeDummyClass(File outputDirectory, String binaryName) throws IOException {
-        ClassWriter cw = new ClassWriter(0);
-        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
-        cw.visitEnd();
+        ClassWriter classWriter = new ClassWriter(0);
+        classWriter.visit(
+                Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
+        classWriter.visitEnd();
         File classFile = new File(outputDirectory, binaryName.replace('.', '/') + ".class");
         Files.createDirectories(classFile.getParentFile().toPath());
-        Files.write(classFile.toPath(), cw.toByteArray());
+        Files.write(classFile.toPath(), classWriter.toByteArray());
     }
 
     static final class Builder {
@@ -83,9 +84,9 @@ final class ModuleInfoFixtures {
         }
 
         byte[] toBytes() {
-            ClassWriter cw = new ClassWriter(0);
-            cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
-            ModuleVisitor mv = cw.visitModule(name, open ? Opcodes.ACC_OPEN : 0, null);
+            ClassWriter classWriter = new ClassWriter(0);
+            classWriter.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+            ModuleVisitor mv = classWriter.visitModule(name, open ? Opcodes.ACC_OPEN : 0, null);
             mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
             for (String module : requires) {
                 mv.visitRequire(module, 0, null);
@@ -97,8 +98,8 @@ final class ModuleInfoFixtures {
                 mv.visitOpen(open.internalName(), 0, open.targetsOrNull());
             }
             mv.visitEnd();
-            cw.visitEnd();
-            return cw.toByteArray();
+            classWriter.visitEnd();
+            return classWriter.toByteArray();
         }
 
         /** Write {@code module-info.class} into {@code outputDirectory} and return that directory. */

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModulesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModulesTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class RequireExplicitModulesTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private RequireExplicitModules rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new RequireExplicitModules(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void aModularProjectWithClassesPasses() throws Exception {
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        ModuleInfoFixtures.module("com.example.foo").exports("com.example.foo").writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void compiledClassesWithoutModuleInfoFail() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("automatic module"), e.getMessage());
+    }
+
+    @Test
+    void aProjectWithNoCompiledClassesPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anOutputWithOnlyModuleInfoPasses() throws Exception {
+        // module-info.class but no other classes: nothing to encapsulate, so the rule stays silent.
+        ModuleInfoFixtures.module("com.example.foo").writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithExplicitModulesPasses() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        File api = new File(outputDirectory, "com.example.api");
+        ModuleInfoFixtures.writeDummyClass(api, "com.example.api.Service");
+        ModuleInfoFixtures.module("com.example.api").exports("com.example.api").writeTo(api);
+        File core = new File(outputDirectory, "com.example.core");
+        ModuleInfoFixtures.writeDummyClass(core, "com.example.core.Impl");
+        ModuleInfoFixtures.module("com.example.core")
+                .requires("com.example.api")
+                .writeTo(core);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithANonModularOutputFails() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        File api = new File(outputDirectory, "com.example.api");
+        ModuleInfoFixtures.writeDummyClass(api, "com.example.api.Service");
+        ModuleInfoFixtures.module("com.example.api").exports("com.example.api").writeTo(api);
+        // sibling output with classes but no module descriptor
+        File legacy = new File(outputDirectory, "com.example.legacy");
+        ModuleInfoFixtures.writeDummyClass(legacy, "com.example.legacy.Old");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.legacy"), e.getMessage());
+    }
+
+    @Test
+    void aCustomMessageIsUsed() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        rule.setMessage("please add module-info.java");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("please add module-info.java"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExportsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExportsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class RequireMinimalExportsTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private RequireMinimalExports rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new RequireMinimalExports(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void exportingOnlyApiPackagesPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void exportingAnInternalPackageFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .exports("com.example.foo.internal")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.foo.internal"), e.getMessage());
+    }
+
+    @Test
+    void qualifiedInternalExportIsIgnoredByDefault() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.example.bar")
+                .exports("com.example.foo.internal", "com.example.bar")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void qualifiedInternalExportFailsWhenNotIgnored() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.example.bar")
+                .exports("com.example.foo.internal", "com.example.bar")
+                .writeTo(outputDirectory);
+        rule.setIgnoreQualifiedExports(false);
+        assertThrows(EnforcerRuleException.class, rule::execute);
+    }
+
+    @Test
+    void whitelistedInternalExportPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.internal")
+                .writeTo(outputDirectory);
+        rule.setAllowedExports(Arrays.asList("com.example.foo.internal"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void customPatternIsHonoured() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.secret")
+                .writeTo(outputDirectory);
+        rule.setInternalPackagePattern(".*\\.secret");
+        assertThrows(EnforcerRuleException.class, rule::execute);
+    }
+
+    @Test
+    void aNonModularProjectPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithCleanExportsPasses() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.core")
+                .exports("com.example.core.service")
+                .writeTo(new File(outputDirectory, "com.example.core"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anInternalExportInAModuleSourceHierarchyFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.core")
+                .exports("com.example.core.internal")
+                .writeTo(new File(outputDirectory, "com.example.core"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.core.internal"), e.getMessage());
+    }
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-unjustified-opens-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>An unqualified opens fails banUnjustifiedOpens</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/dto/Dto.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/dto/Dto.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.dto;
+
+public class Dto {}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    opens com.example.it.dto;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.BanUnjustifiedOpens failed with message')
+assert buildLog.text.contains('opens package(s)')
+assert buildLog.text.contains('com.example.it.dto')

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+# process-classes compiles module-info.java before the enforcer execution runs
+invoker.goals = process-classes
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-info-rules-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>A well-encapsulated explicit module passes all three module rules</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                        <requireMinimalExports/>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <!-- after compile: the rules read the compiled module-info.class -->
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+/** Public API type — its package is the only unqualified export. */
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/dto/Dto.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/dto/Dto.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.dto;
+
+/** Reflected over by Jackson — its package is opened, but only to that named module. */
+public class Dto {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/internal/Helper.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/internal/Helper.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.internal;
+
+/** Internal detail — deliberately neither exported nor opened. */
+class Helper {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    opens com.example.it.dto to com.fasterxml.jackson.databind;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert !buildLog.text.contains('failed with message')
+// sanity: the module descriptor really was compiled and thus available to the rules
+assert new File(basedir, 'target/classes/module-info.class').exists()

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# module source hierarchy (POM model 4.1.0) needs Maven 4; that in turn needs JDK 17+
+invoker.maven.version = 4.0.0-rc-5+
+invoker.java.version = 17+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+    root="true">
+    <modelVersion>4.1.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-source-hierarchy-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>One module in a Maven 4 module source hierarchy exports an internal package</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <!-- Maven 4 module source hierarchy: each module compiles to target/classes/<module-name>/ -->
+        <sources>
+            <source>
+                <module>com.example.api</module>
+            </source>
+            <source>
+                <module>com.example.core</module>
+            </source>
+        </sources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>4.0.0-beta-3</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireMinimalExports/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/com/example/api/Api.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/com/example/api/Api.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.api;
+
+public class Api {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.api {
+    exports com.example.api;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/com/example/core/internal/Impl.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/com/example/core/internal/Impl.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.core.internal;
+
+public class Impl {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.core {
+    requires com.example.api;
+    exports com.example.core.internal;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireMinimalExports failed with message')
+assert buildLog.text.contains('exports internal package(s)')
+// the offending module in the hierarchy is named, the clean one is not flagged
+assert buildLog.text.contains('com.example.core.internal')

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# module source hierarchy (POM model 4.1.0) needs Maven 4; that in turn needs JDK 17+
+invoker.maven.version = 4.0.0-rc-5+
+invoker.java.version = 17+
+invoker.goals = process-classes
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+    root="true">
+    <modelVersion>4.1.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-source-hierarchy-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Two well-encapsulated modules compiled from a Maven 4 module source hierarchy pass all rules</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <!-- Maven 4 module source hierarchy: each module compiles to target/classes/<module-name>/ -->
+        <sources>
+            <source>
+                <module>com.example.api</module>
+            </source>
+            <source>
+                <module>com.example.core</module>
+            </source>
+        </sources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>4.0.0-beta-3</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                        <requireMinimalExports/>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/com/example/api/Api.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/com/example/api/Api.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.api;
+
+public class Api {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.api {
+    exports com.example.api;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/com/example/core/service/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/com/example/core/service/Service.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.core.service;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.core {
+    requires com.example.api;
+    exports com.example.core.service;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert !buildLog.text.contains('failed with message')
+// the module source hierarchy really produced one output per module
+assert new File(basedir, 'target/classes/com.example.api/module-info.class').exists()
+assert new File(basedir, 'target/classes/com.example.core/module-info.class').exists()

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# these ITs compile a module-info.java (release 11); skip on JDK < 11
+# this IT compiles classes WITHOUT a module-info.java to exercise requireExplicitModules;
+# gated to JDK 11+ for parity with the modular ITs in this suite
 invoker.java.version = 11+
 invoker.goals = process-classes
 invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>require-explicit-modules-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>A project with classes but no module-info.class is not an explicit module</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/src/main/java/com/example/it/App.java
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/src/main/java/com/example/it/App.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it;
+
+/** Compiled class with no module-info.java — the artifact would be an automatic module. */
+public class App {}

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireExplicitModules failed with message')
+assert buildLog.text.contains('is not an explicit Java module')

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>require-minimal-exports-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Exporting an internal package fails requireMinimalExports</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireMinimalExports/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/internal/Impl.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/internal/Impl.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.internal;
+
+/** Internal detail that must not be part of the module's public surface. */
+public class Impl {}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    exports com.example.it.internal;
+}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireMinimalExports failed with message')
+assert buildLog.text.contains('exports internal package(s)')
+assert buildLog.text.contains('com.example.it.internal')


### PR DESCRIPTION
Implements the three deterministic Java module rules proposed in #995.

## Rules

- **`requireExplicitModules`** — fails a project that compiles classes but has no `module-info.class`, so an artifact never silently resolves as an *automatic module*.
- **`requireMinimalExports`** — fails a module that `exports` an internal/impl package (configurable `internalPackagePattern`, `allowedExports` whitelist, `ignoreQualifiedExports`).
- **`banUnjustifiedOpens`** — fails an unqualified `opens` (or an `open module`); qualified `opens … to` and an `allowedOpens` whitelist pass.

Each reads the compiled `module-info.class`, so its `enforce` execution must run **after compilation** (e.g. bound to `process-classes`). They support both the classic layout (one `module-info.class` in the output directory) and the **Maven 4 module source hierarchy** (POM model 4.1.0), where one project compiles several modules, each to `${project.build.outputDirectory}/<module-name>/`.

## `module-info` reader — design note

The rules read `module-info.class` through `java.lang.module.ModuleDescriptor`, accessed **reflectively**. The plugin compiles with `--release 8` and so cannot reference the Java 9 `ModuleDescriptor` API directly. The obvious alternative — a multi-release JAR overlay compiled for Java 9 — is deliberately avoided: MRJAR support in Maven 3 is incomplete and can produce invalid JARs (cf. MNG-6892 / MNG-6293, `maven-jar-plugin#484`), and is only cleanly solved in Maven 4. Reflection keeps the rules usable on **Maven 3 with a Java 8 baseline**: the API is present at runtime whenever a `module-info.class` exists (such a project is necessarily built on Java 9+), and the rules do nothing when there is no descriptor. The reader also fails with a **clear diagnostic** — rather than silently — when a `module-info.class` is a newer class-file version than the JVM running the build.

## Tests

- Unit tests for the reader and each rule (guarded to Java 9+; ASM is used in **test scope only** to generate `module-info.class` fixtures — production stays dependency-free).
- ITs under `maven-enforcer-plugin/src/it/projects/`: four classic single-module (one pass, three fail) plus two Maven 4 module-source-hierarchy (pass/fail), gated by JDK / Maven version so they skip cleanly on older toolchains.
- Site pages for the three rules, listed in the built-in rules index.

A follow-up rule for split-package detection across the module path is planned separately.
