### PR TITLE
Add banSplitPackages rule: module-path split-package detection

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -159,6 +159,14 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- test only: generates module-info.class fixtures for the module rules; production code reads
+         module-info via java.lang.module.ModuleDescriptor (accessed reflectively, see JavaModuleInfoReader). -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/ResolverUtil.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/ResolverUtil.java
@@ -54,7 +54,7 @@ import static org.apache.maven.artifact.Artifact.SCOPE_TEST;
  * Resolver helper class.
  */
 @Named
-class ResolverUtil {
+public class ResolverUtil {
 
     private final RepositorySystem repositorySystem;
 
@@ -117,7 +117,7 @@ class ResolverUtil {
         return resolveTransitiveDependencies(verbose, false, excludeOptional, excludedScopes);
     }
 
-    DependencyNode resolveTransitiveDependencies(
+    public DependencyNode resolveTransitiveDependencies(
             boolean verbose, boolean resolve, boolean excludeOptional, List<String> excludedScopes)
             throws EnforcerRuleException {
 

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.AbstractStandardEnforcerRule;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Base class for rules that inspect the {@code module-info.class} of the project's main output.
+ * Two output layouts are supported:
+ *
+ * <ul>
+ *   <li><b>Classic</b>: the descriptor sits directly in {@code ${project.build.outputDirectory}}
+ *       (one Maven project = one Java module);</li>
+ *   <li><b>Module source hierarchy</b> (Maven&nbsp;4, POM model 4.1.0): one Maven project compiles
+ *       several modules, each to its own subdirectory
+ *       {@code ${project.build.outputDirectory}/<module-name>/module-info.class}.</li>
+ * </ul>
+ *
+ * Subclasses call {@link #moduleOutputs()} and enforce a specific constraint on each returned
+ * {@link ModuleOutput}.
+ */
+abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
+
+    protected final MavenProject project;
+
+    protected AbstractModuleInfoRule(MavenProject project) {
+        this.project = project;
+    }
+
+    /** One compiled output that may form a Java module. */
+    protected static final class ModuleOutput {
+        private final File root;
+        private final JavaModuleInfo moduleInfo;
+
+        private ModuleOutput(File root, JavaModuleInfo moduleInfo) {
+            this.root = root;
+            this.moduleInfo = moduleInfo;
+        }
+
+        /** The directory the module's classes are compiled to. */
+        File root() {
+            return root;
+        }
+
+        /** The parsed module descriptor, or {@code null} if {@link #root()} has no {@code module-info.class}. */
+        JavaModuleInfo moduleInfo() {
+            return moduleInfo;
+        }
+    }
+
+    /** The directory the main classes (and any {@code module-info.class}) are compiled to. */
+    protected File outputDirectory() {
+        return new File(project.getBuild().getOutputDirectory());
+    }
+
+    /**
+     * Discover the project's module outputs.
+     *
+     * <p>If the output directory itself holds a {@code module-info.class} (classic layout), exactly
+     * that one output is returned. Otherwise, if at least one first-level subdirectory holds a
+     * {@code module-info.class} (Maven&nbsp;4 module source hierarchy), every first-level
+     * subdirectory is returned as one output each — including non-modular ones, whose
+     * {@link ModuleOutput#moduleInfo()} is {@code null}, so rules can flag them. Failing both, the
+     * output directory is returned as a single non-modular output.
+     *
+     * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
+     */
+    protected List<ModuleOutput> moduleOutputs() throws EnforcerRuleException {
+        File outputDirectory = outputDirectory();
+        JavaModuleInfo topLevel = readModuleInfo(outputDirectory);
+        if (topLevel != null) {
+            return Collections.singletonList(new ModuleOutput(outputDirectory, topLevel));
+        }
+        File[] subdirectories = outputDirectory.listFiles(File::isDirectory);
+        if (subdirectories != null) {
+            Arrays.sort(subdirectories);
+            List<ModuleOutput> outputs = new ArrayList<>();
+            boolean modular = false;
+            for (File subdirectory : subdirectories) {
+                JavaModuleInfo moduleInfo = readModuleInfo(subdirectory);
+                modular |= moduleInfo != null;
+                outputs.add(new ModuleOutput(subdirectory, moduleInfo));
+            }
+            if (modular) {
+                getLog().debug("Detected module source hierarchy layout below " + outputDirectory + " ("
+                        + outputs.size() + " module output(s))");
+                return outputs;
+            }
+        }
+        return Collections.singletonList(new ModuleOutput(outputDirectory, null));
+    }
+
+    /**
+     * Read the module descriptor of one output directory.
+     *
+     * @return the parsed {@link JavaModuleInfo}, or {@code null} if the directory has no
+     *         {@code module-info.class}
+     * @throws EnforcerRuleException if a {@code module-info.class} exists but cannot be read
+     */
+    private JavaModuleInfo readModuleInfo(File directory) throws EnforcerRuleException {
+        File moduleInfo = new File(directory, "module-info.class");
+        if (!moduleInfo.isFile()) {
+            getLog().debug("No module-info.class in " + directory);
+            return null;
+        }
+        try (InputStream in = Files.newInputStream(moduleInfo.toPath())) {
+            return JavaModuleInfoReader.read(in);
+        } catch (IOException e) {
+            throw new EnforcerRuleException("Failed to read " + moduleInfo + ": " + e.getMessage(), e);
+        }
+    }
+
+    /** Short rule name for log messages, e.g. {@code RequireMinimalExports}. */
+    protected String ruleName() {
+        return getClass().getSimpleName();
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/AbstractModuleInfoRule.java
@@ -38,7 +38,7 @@ import org.apache.maven.project.MavenProject;
  * <ul>
  *   <li><b>Classic</b>: the descriptor sits directly in {@code ${project.build.outputDirectory}}
  *       (one Maven project = one Java module);</li>
- *   <li><b>Module source hierarchy</b> (Maven&nbsp;4, POM model 4.1.0): one Maven project compiles
+ *   <li><b>Module source hierarchy</b> (Maven 4, POM model 4.1.0): one Maven project compiles
  *       several modules, each to its own subdirectory
  *       {@code ${project.build.outputDirectory}/<module-name>/module-info.class}.</li>
  * </ul>
@@ -46,7 +46,7 @@ import org.apache.maven.project.MavenProject;
  * Subclasses call {@link #moduleOutputs()} and enforce a specific constraint on each returned
  * {@link ModuleOutput}.
  */
-abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
+public abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
 
     protected final MavenProject project;
 
@@ -85,7 +85,7 @@ abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
      *
      * <p>If the output directory itself holds a {@code module-info.class} (classic layout), exactly
      * that one output is returned. Otherwise, if at least one first-level subdirectory holds a
-     * {@code module-info.class} (Maven&nbsp;4 module source hierarchy), every first-level
+     * {@code module-info.class} (Maven 4 module source hierarchy), every first-level
      * subdirectory is returned as one output each — including non-modular ones, whose
      * {@link ModuleOutput#moduleInfo()} is {@code null}, so rules can flag them. Failing both, the
      * output directory is returned as a single non-modular output.
@@ -137,7 +137,7 @@ abstract class AbstractModuleInfoRule extends AbstractStandardEnforcerRule {
         }
     }
 
-    /** Short rule name for log messages, e.g. {@code RequireMinimalExports}. */
+    /** Short rule name for log messages, such as {@code RequireMinimalExports}. */
     protected String ruleName() {
         return getClass().getSimpleName();
     }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/ArtifactModuleScanner.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/ArtifactModuleScanner.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+/**
+ * Determines the module identity and package set of one dependency artifact (a JAR or an exploded
+ * classes directory, e.g. a reactor sibling's {@code target/classes}).
+ *
+ * <p>Modular artifacts and automatic modules are read through
+ * {@code java.lang.module.ModuleFinder}, which derives automatic-module names and always reports
+ * the complete package set. Like {@link JavaModuleInfoReader}, the Java&nbsp;9 module API is
+ * accessed reflectively to keep the Java&nbsp;8 compile baseline (see the design note there).
+ * Artifacts the finder cannot model (no descriptor and no derivable automatic name, or running on
+ * a Java&nbsp;8 JVM) fall back to a plain class-file scan and are reported as non-modular.</p>
+ */
+final class ArtifactModuleScanner {
+
+    private ArtifactModuleScanner() {}
+
+    /** The module view of one scanned artifact. */
+    static final class ScannedArtifact {
+        private final JavaModuleInfo moduleInfo;
+        private final boolean automatic;
+        private final Set<String> packages;
+
+        private ScannedArtifact(JavaModuleInfo moduleInfo, boolean automatic, Set<String> packages) {
+            this.moduleInfo = moduleInfo;
+            this.automatic = automatic;
+            this.packages = packages;
+        }
+
+        /**
+         * The module descriptor ({@link JavaModuleInfo#packages()} filled from
+         * {@code ModuleDescriptor.packages()}), or {@code null} for a non-modular artifact.
+         */
+        JavaModuleInfo moduleInfo() {
+            return moduleInfo;
+        }
+
+        /** {@code true} if the descriptor was derived for an automatic module (plain JAR). */
+        boolean isAutomatic() {
+            return automatic;
+        }
+
+        /** All packages containing at least one class file. */
+        Set<String> packages() {
+            return packages;
+        }
+    }
+
+    /**
+     * Scan one artifact.
+     *
+     * @param file the artifact's JAR file or classes directory
+     * @return the scanned module view, never {@code null}
+     * @throws IOException if the artifact cannot be read at all
+     */
+    static ScannedArtifact scan(File file) throws IOException {
+        // A directory without module-info.class must not go through ModuleFinder: the finder would
+        // treat it as a *directory of modules* and scan its entries, yielding nonsense.
+        boolean tryFinder = file.isFile() || new File(file, "module-info.class").isFile();
+        if (tryFinder && isModuleApiAvailable()) {
+            try {
+                ScannedArtifact scanned = scanWithModuleFinder(file);
+                if (scanned != null) {
+                    return scanned;
+                }
+            } catch (InvocationTargetException e) {
+                // e.g. FindException for a JAR whose file name yields no valid automatic-module
+                // name — legal on the classpath, so degrade to a non-modular scan.
+            } catch (ReflectiveOperationException e) {
+                throw new IOException("Could not read module information of " + file, e);
+            }
+        }
+        return new ScannedArtifact(null, false, scanPackages(file));
+    }
+
+    private static boolean isModuleApiAvailable() {
+        try {
+            Class.forName("java.lang.module.ModuleFinder");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /** Read the artifact through {@code ModuleFinder.of(path)}; {@code null} if it finds no module. */
+    private static ScannedArtifact scanWithModuleFinder(File file) throws ReflectiveOperationException {
+        Class<?> finderType = Class.forName("java.lang.module.ModuleFinder");
+        Object pathArray = Array.newInstance(Path.class, 1);
+        Array.set(pathArray, 0, file.toPath());
+        // wrap: a bare Path[] argument would be unpacked by Method.invoke as the whole varargs list
+        Object finder = finderType.getMethod("of", Path[].class).invoke(null, new Object[] {pathArray});
+        Set<?> references = (Set<?>) finderType.getMethod("findAll").invoke(finder);
+        if (references.size() != 1) {
+            return null;
+        }
+        Object reference = references.iterator().next();
+        Object descriptor = Class.forName("java.lang.module.ModuleReference")
+                .getMethod("descriptor")
+                .invoke(reference);
+        boolean automatic = (Boolean) Class.forName("java.lang.module.ModuleDescriptor")
+                .getMethod("isAutomatic")
+                .invoke(descriptor);
+        JavaModuleInfo moduleInfo = JavaModuleInfoReader.fromDescriptor(descriptor);
+        return new ScannedArtifact(moduleInfo, automatic, moduleInfo.packages());
+    }
+
+    /** Plain scan: every package that holds at least one {@code .class} file. */
+    private static Set<String> scanPackages(File file) throws IOException {
+        Set<String> packages = new TreeSet<String>();
+        if (file.isDirectory()) {
+            collectPackages(file, "", packages);
+        } else if (file.isFile()) {
+            try (JarFile jar = new JarFile(file)) {
+                for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements(); ) {
+                    ZipEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    int slash = name.lastIndexOf('/');
+                    if (slash > 0 && name.endsWith(".class") && !name.startsWith("META-INF/")) {
+                        packages.add(name.substring(0, slash).replace('/', '.'));
+                    }
+                }
+            }
+        }
+        return packages;
+    }
+
+    private static void collectPackages(File directory, String packageName, Set<String> packages) {
+        File[] entries = directory.listFiles();
+        if (entries == null) {
+            return;
+        }
+        for (File entry : entries) {
+            if (entry.isDirectory()) {
+                String childPackage = packageName.isEmpty() ? entry.getName() : packageName + "." + entry.getName();
+                collectPackages(entry, childPackage, packages);
+            } else if (!packageName.isEmpty() && entry.getName().endsWith(".class")) {
+                packages.add(packageName);
+            }
+        }
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanSplitPackages.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanSplitPackages.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.dependency.ResolverUtil;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.graph.DependencyNode;
+
+/**
+ * Bans <em>split packages</em>: a package contained in more than one Java module. The boot layer
+ * rejects two modules on the module path that contain the same package
+ * ({@code java.lang.module.ResolutionException}), and if the offending module happens not to be
+ * {@code requires}d, the build stays green while a type or endpoint is silently absent at runtime.
+ * Split packages are typically introduced by accident — a code generator, a shaded/unpacked
+ * dependency, or a copied resource placing classes of a foreign package into the project's output.
+ *
+ * <p>The rule intersects the package sets of the project's compiled output(s) (classic layout and
+ * the Maven&nbsp;4 module source hierarchy) and of every declared dependency — deliberately
+ * <em>not</em> only the {@code requires}d modules, which is exactly what catches the silent
+ * variant. Overlaps between two modules that would both end up on the module path are errors;
+ * overlaps involving a plain classpath artifact are legal today and reported at
+ * {@code <classpathSeverity>} (default {@code warn}) as a modularization hazard.</p>
+ */
+@Named("banSplitPackages")
+public final class BanSplitPackages extends AbstractModuleInfoRule {
+
+    /** Severity for overlaps involving an artifact that is not on the module path. */
+    private static final String SEVERITY_WARN = "warn";
+
+    private static final String SEVERITY_ERROR = "error";
+    private static final String SEVERITY_IGNORE = "ignore";
+
+    /**
+     * Severity for overlaps involving a non-modular (classpath) artifact:
+     * {@code warn} (default), {@code error} or {@code ignore}.
+     */
+    private String classpathSeverity = SEVERITY_WARN;
+
+    /** Packages permitted to overlap. */
+    private List<String> allowedSplitPackages = new ArrayList<>();
+
+    /** Module names whose artifacts are excluded from the check. */
+    private List<String> ignoredModules = new ArrayList<>();
+
+    /** Dependencies excluded from the check, as {@code groupId:artifactId}. */
+    private List<String> ignoredArtifacts = new ArrayList<>();
+
+    private final ResolverUtil resolverUtil;
+
+    @Inject
+    public BanSplitPackages(MavenProject project, ResolverUtil resolverUtil) {
+        super(project);
+        this.resolverUtil = resolverUtil;
+    }
+
+    public void setClasspathSeverity(String classpathSeverity) {
+        this.classpathSeverity = classpathSeverity;
+    }
+
+    public void setAllowedSplitPackages(List<String> allowedSplitPackages) {
+        this.allowedSplitPackages = allowedSplitPackages;
+    }
+
+    public void setIgnoredModules(List<String> ignoredModules) {
+        this.ignoredModules = ignoredModules;
+    }
+
+    public void setIgnoredArtifacts(List<String> ignoredArtifacts) {
+        this.ignoredArtifacts = ignoredArtifacts;
+    }
+
+    /** One holder of a package set: a project module output or a dependency artifact. */
+    private static final class PackageOwner {
+        private final String display;
+        private final JavaModuleInfo module;
+        private final boolean automatic;
+        private final Set<String> packages;
+
+        private PackageOwner(String display, JavaModuleInfo module, boolean automatic, Set<String> packages) {
+            this.display = display;
+            this.module = module;
+            this.automatic = automatic;
+            this.packages = packages;
+        }
+    }
+
+    /** One detected overlap. */
+    private static final class Overlap {
+        private final String packageName;
+        private final PackageOwner first;
+        private final PackageOwner second;
+        private final boolean modulePath;
+
+        private Overlap(String packageName, PackageOwner first, PackageOwner second, boolean modulePath) {
+            this.packageName = packageName;
+            this.first = first;
+            this.second = second;
+            this.modulePath = modulePath;
+        }
+
+        private String describe() {
+            return "package " + packageName + " is contained in " + first.display + " and " + second.display;
+        }
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        if (!Arrays.asList(SEVERITY_WARN, SEVERITY_ERROR, SEVERITY_IGNORE).contains(classpathSeverity)) {
+            throw new EnforcerRuleException(
+                    "Invalid <classpathSeverity> '" + classpathSeverity + "': use warn, error or ignore");
+        }
+
+        List<PackageOwner> owners = new ArrayList<>();
+        Set<String> projectRequires = new HashSet<>();
+        collectProjectOutputs(owners, projectRequires);
+        collectDependencies(owners);
+
+        List<Overlap> overlaps = findOverlaps(owners, projectRequires);
+        report(overlaps);
+    }
+
+    /** One package owner per compiled project output; also accumulates the project's {@code requires}. */
+    private void collectProjectOutputs(List<PackageOwner> owners, Set<String> projectRequires)
+            throws EnforcerRuleException {
+        for (ModuleOutput output : moduleOutputs()) {
+            Set<String> packages = new TreeSet<>();
+            collectOutputPackages(output.root(), "", packages);
+            JavaModuleInfo module = output.moduleInfo();
+            if (module != null) {
+                projectRequires.addAll(module.requires());
+            }
+            if (module == null && packages.isEmpty()) {
+                continue; // e.g. an empty output directory
+            }
+            String display = module != null
+                    ? "module " + module.name() + " (project output "
+                            + output.root().getName() + ")"
+                    : "the non-modular project output " + output.root();
+            if (module != null && ignoredModules.contains(module.name())) {
+                continue;
+            }
+            // The compiled module-info's package list is only finalized at packaging time, and
+            // offending classes are frequently added after compile (generation, copy) — so the
+            // walked directory content is authoritative, not the descriptor.
+            owners.add(new PackageOwner(display, module, false, packages));
+        }
+    }
+
+    /** Every package below {@code directory} that holds at least one class file. */
+    private void collectOutputPackages(File directory, String packageName, Set<String> packages) {
+        File[] entries = directory.listFiles();
+        if (entries == null) {
+            return;
+        }
+        for (File entry : entries) {
+            if (entry.isDirectory()) {
+                String childPackage = packageName.isEmpty() ? entry.getName() : packageName + "." + entry.getName();
+                collectOutputPackages(entry, childPackage, packages);
+            } else if (!packageName.isEmpty() && entry.getName().endsWith(".class")) {
+                packages.add(packageName);
+            }
+        }
+    }
+
+    /** One package owner per resolved declared dependency (test scope excluded). */
+    private void collectDependencies(List<PackageOwner> owners) throws EnforcerRuleException {
+        DependencyNode root =
+                resolverUtil.resolveTransitiveDependencies(false, true, false, Arrays.asList(Artifact.SCOPE_TEST));
+        Map<File, String> artifactFiles = new LinkedHashMap<>();
+        collectArtifactFiles(root, true, artifactFiles, new HashSet<>());
+        for (Map.Entry<File, String> entry : artifactFiles.entrySet()) {
+            File file = entry.getKey();
+            String id = entry.getValue();
+            if (!file.isDirectory() && !file.getName().endsWith(".jar")) {
+                continue;
+            }
+            ArtifactModuleScanner.ScannedArtifact scanned;
+            try {
+                scanned = ArtifactModuleScanner.scan(file);
+            } catch (IOException e) {
+                throw new EnforcerRuleException("Failed to scan dependency " + id + ": " + e.getMessage(), e);
+            }
+            JavaModuleInfo module = scanned.moduleInfo();
+            if (module != null && ignoredModules.contains(module.name())) {
+                continue;
+            }
+            String display = module != null
+                    ? "module " + module.name() + " (" + id + (scanned.isAutomatic() ? ", automatic)" : ")")
+                    : "the non-modular dependency " + id;
+            owners.add(new PackageOwner(display, module, scanned.isAutomatic(), scanned.packages()));
+        }
+    }
+
+    private void collectArtifactFiles(
+            DependencyNode node, boolean isRoot, Map<File, String> collected, Set<DependencyNode> visited) {
+        if (!visited.add(node)) {
+            return;
+        }
+        if (!isRoot && node.getArtifact() != null) {
+            org.eclipse.aether.artifact.Artifact artifact = node.getArtifact();
+            if (artifact.getFile() != null
+                    && !ignoredArtifacts.contains(artifact.getGroupId() + ":" + artifact.getArtifactId())) {
+                collected.putIfAbsent(artifact.getFile(), artifact.toString());
+            }
+        }
+        for (DependencyNode child : node.getChildren()) {
+            collectArtifactFiles(child, false, collected, visited);
+        }
+    }
+
+    private List<Overlap> findOverlaps(List<PackageOwner> owners, Set<String> projectRequires) {
+        List<Overlap> overlaps = new ArrayList<>();
+        for (int i = 0; i < owners.size(); i++) {
+            for (int j = i + 1; j < owners.size(); j++) {
+                PackageOwner first = owners.get(i);
+                PackageOwner second = owners.get(j);
+                Set<String> shared = new TreeSet<>(first.packages);
+                shared.retainAll(second.packages);
+                shared.removeAll(allowedSplitPackages);
+                if (shared.isEmpty()) {
+                    continue;
+                }
+                boolean modulePath = isOnModulePath(first, projectRequires) && isOnModulePath(second, projectRequires);
+                for (String packageName : shared) {
+                    overlaps.add(new Overlap(packageName, first, second, modulePath));
+                }
+            }
+        }
+        return overlaps;
+    }
+
+    /**
+     * Whether the owner ends up on the module path: an explicit module always does (for the silent
+     * variant it is exactly the not-{@code requires}d explicit module that breaks late); an
+     * automatic module only when the project actually {@code requires} its derived name; a
+     * non-modular artifact never does.
+     */
+    private boolean isOnModulePath(PackageOwner owner, Set<String> projectRequires) {
+        if (owner.module == null) {
+            return false;
+        }
+        return !owner.automatic || projectRequires.contains(owner.module.name());
+    }
+
+    private void report(List<Overlap> overlaps) throws EnforcerRuleException {
+        Set<String> failures = new LinkedHashSet<>();
+        for (Overlap overlap : overlaps) {
+            if (overlap.modulePath) {
+                failures.add(overlap.describe());
+            } else if (SEVERITY_ERROR.equals(classpathSeverity)) {
+                failures.add(overlap.describe() + " (classpath overlap, <classpathSeverity> is 'error')");
+            } else if (SEVERITY_WARN.equals(classpathSeverity)) {
+                getLog().warn(ruleName() + ": " + overlap.describe()
+                        + " — legal on the classpath, but will break a move to the module path");
+            }
+        }
+        if (!failures.isEmpty()) {
+            String message = getMessage();
+            StringBuilder buf = new StringBuilder(
+                    message != null
+                            ? message
+                            : "Split package(s) found — a package must belong to exactly one module:");
+            for (String failure : failures) {
+                buf.append(System.lineSeparator()).append("  ").append(failure);
+            }
+            if (message == null) {
+                buf.append(System.lineSeparator())
+                        .append("Move the offending classes into the module that owns the package, or list the ")
+                        .append("package in <allowedSplitPackages> if the overlap is intentional.");
+            }
+            throw new EnforcerRuleException(buf.toString());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "BanSplitPackages[classpathSeverity=%s, allowedSplitPackages=%s, ignoredModules=%s, "
+                        + "ignoredArtifacts=%s, message=%s]",
+                classpathSeverity, allowedSplitPackages, ignoredModules, ignoredArtifacts, getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
@@ -48,7 +48,7 @@ public final class BanUnjustifiedOpens extends AbstractModuleInfoRule {
     }
 
     public void setAllowedOpens(List<String> allowedOpens) {
-        this.allowedOpens = allowedOpens;
+        this.allowedOpens = allowedOpens != null ? allowedOpens : new ArrayList<>();
     }
 
     @Override

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpens.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Bans unqualified deep-reflection access into a module. A bare {@code opens a.b.c;} (or an
+ * {@code open module}) grants every other module reflective access to a package's private members,
+ * which defeats strong encapsulation. A framework that needs reflective access should be named
+ * explicitly with a qualified {@code opens a.b.c to some.framework;}.
+ *
+ * <p>Packages that genuinely must be opened to the whole world can be listed in
+ * {@code <allowedOpens>} to pass the check.
+ */
+@Named("banUnjustifiedOpens")
+public final class BanUnjustifiedOpens extends AbstractModuleInfoRule {
+
+    /** Packages allowed to be opened unqualifiedly despite the ban. */
+    private List<String> allowedOpens = new ArrayList<>();
+
+    @Inject
+    public BanUnjustifiedOpens(MavenProject project) {
+        super(project);
+    }
+
+    public void setAllowedOpens(List<String> allowedOpens) {
+        this.allowedOpens = allowedOpens;
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        for (ModuleOutput output : moduleOutputs()) {
+            JavaModuleInfo module = output.moduleInfo();
+            if (module != null) {
+                checkModule(module);
+            }
+        }
+    }
+
+    private void checkModule(JavaModuleInfo module) throws EnforcerRuleException {
+        if (module.isOpen()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " is declared as an 'open module', opening every package for "
+                                    + "deep reflection. Declare a normal module and use qualified 'opens ... to <module>' "
+                                    + "for the packages that actually need it.");
+        }
+
+        List<String> violations = new ArrayList<>();
+        for (JavaModuleInfo.Directive open : module.opens()) {
+            if (!open.isQualified() && !allowedOpens.contains(open.packageName())) {
+                violations.add(open.packageName());
+            }
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " opens package(s) " + violations + " unqualifiedly. Use a "
+                                    + "qualified 'opens ... to <module>', or list the package in <allowedOpens>.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("BanUnjustifiedOpens[allowedOpens=%s, message=%s]", allowedOpens, getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -20,10 +20,12 @@ package org.apache.maven.enforcer.rules.modules;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Immutable view of the {@code Module} attribute of a {@code module-info.class}:
- * the module name plus its {@code requires} / {@code exports} / {@code opens} directives.
+ * the module name plus its {@code requires} / {@code exports} / {@code opens} directives
+ * and the module's package set.
  * Package and module names are in the source form (dot-separated).
  */
 final class JavaModuleInfo {
@@ -33,13 +35,21 @@ final class JavaModuleInfo {
     private final List<String> requires;
     private final List<Directive> exports;
     private final List<Directive> opens;
+    private final Set<String> packages;
 
-    JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
+    JavaModuleInfo(
+            String name,
+            boolean open,
+            List<String> requires,
+            List<Directive> exports,
+            List<Directive> opens,
+            Set<String> packages) {
         this.name = name;
         this.open = open;
         this.requires = Collections.unmodifiableList(requires);
         this.exports = Collections.unmodifiableList(exports);
         this.opens = Collections.unmodifiableList(opens);
+        this.packages = Collections.unmodifiableSet(packages);
     }
 
     /** The module name, e.g. {@code com.example.foo}. */
@@ -68,6 +78,19 @@ final class JavaModuleInfo {
     /** {@code opens} directives. */
     List<Directive> opens() {
         return opens;
+    }
+
+    /**
+     * All packages of the module, as reported by {@code ModuleDescriptor.packages()}.
+     *
+     * <p>Complete when the descriptor comes from a packaged artifact (the {@code ModulePackages}
+     * attribute is written at packaging time, and {@code ModuleFinder} falls back to scanning the
+     * artifact). For a bare {@code module-info.class} read from an output directory it may contain
+     * only the exported/opened packages — enumerate the directory instead when completeness
+     * matters there.</p>
+     */
+    Set<String> packages() {
+        return packages;
     }
 
     /** A single {@code exports}/{@code opens} directive: a package and its optional target modules. */

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable view of the {@code Module} attribute of a {@code module-info.class}:
+ * the module name plus its {@code requires} / {@code exports} / {@code opens} directives.
+ * Package and module names are in the source form (dot-separated).
+ */
+final class JavaModuleInfo {
+
+    private final String name;
+    private final boolean open;
+    private final List<String> requires;
+    private final List<Directive> exports;
+    private final List<Directive> opens;
+
+    JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
+        this.name = name;
+        this.open = open;
+        this.requires = Collections.unmodifiableList(requires);
+        this.exports = Collections.unmodifiableList(exports);
+        this.opens = Collections.unmodifiableList(opens);
+    }
+
+    /** The module name, e.g. {@code com.example.foo}. */
+    String name() {
+        return name;
+    }
+
+    /**
+     * {@code true} for an {@code open module}, which implicitly opens <em>all</em> its packages for
+     * deep reflection (its {@link #opens()} list is then empty).
+     */
+    boolean isOpen() {
+        return open;
+    }
+
+    /** Names of required modules. */
+    List<String> requires() {
+        return requires;
+    }
+
+    /** {@code exports} directives. */
+    List<Directive> exports() {
+        return exports;
+    }
+
+    /** {@code opens} directives. */
+    List<Directive> opens() {
+        return opens;
+    }
+
+    /** A single {@code exports}/{@code opens} directive: a package and its optional target modules. */
+    static final class Directive {
+        private final String packageName;
+        private final List<String> targets;
+
+        Directive(String packageName, List<String> targets) {
+            this.packageName = packageName;
+            this.targets = Collections.unmodifiableList(targets);
+        }
+
+        /** Exported/opened package, e.g. {@code com.example.foo.api}. */
+        String packageName() {
+            return packageName;
+        }
+
+        /** Target modules for a qualified directive; empty for an unqualified one. */
+        List<String> targets() {
+            return targets;
+        }
+
+        /** {@code true} if this is a qualified {@code exports ... to} / {@code opens ... to}. */
+        boolean isQualified() {
+            return !targets.isEmpty();
+        }
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.enforcer.rules.modules;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,12 +38,14 @@ final class JavaModuleInfo {
     JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
         this.name = name;
         this.open = open;
-        this.requires = Collections.unmodifiableList(requires);
-        this.exports = Collections.unmodifiableList(exports);
-        this.opens = Collections.unmodifiableList(opens);
+        // Defensive copies: decouple from the caller's lists so this view stays truly immutable
+        // (List.copyOf would be simpler but is Java 9+; this class compiles with --release 8).
+        this.requires = Collections.unmodifiableList(new ArrayList<>(requires));
+        this.exports = Collections.unmodifiableList(new ArrayList<>(exports));
+        this.opens = Collections.unmodifiableList(new ArrayList<>(opens));
     }
 
-    /** The module name, e.g. {@code com.example.foo}. */
+    /** The module name, such as {@code com.example.foo}. */
     String name() {
         return name;
     }
@@ -77,10 +80,10 @@ final class JavaModuleInfo {
 
         Directive(String packageName, List<String> targets) {
             this.packageName = packageName;
-            this.targets = Collections.unmodifiableList(targets);
+            this.targets = Collections.unmodifiableList(new ArrayList<>(targets));
         }
 
-        /** Exported/opened package, e.g. {@code com.example.foo.api}. */
+        /** Exported/opened package, such as {@code com.example.foo.api}. */
         String packageName() {
             return packageName;
         }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfo.java
@@ -20,11 +20,14 @@ package org.apache.maven.enforcer.rules.modules;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Immutable view of the {@code Module} attribute of a {@code module-info.class}:
- * the module name plus its {@code requires} / {@code exports} / {@code opens} directives.
+ * the module name plus its {@code requires} / {@code exports} / {@code opens} directives
+ * and the module's package set.
  * Package and module names are in the source form (dot-separated).
  */
 final class JavaModuleInfo {
@@ -34,15 +37,23 @@ final class JavaModuleInfo {
     private final List<String> requires;
     private final List<Directive> exports;
     private final List<Directive> opens;
+    private final Set<String> packages;
 
-    JavaModuleInfo(String name, boolean open, List<String> requires, List<Directive> exports, List<Directive> opens) {
+    JavaModuleInfo(
+            String name,
+            boolean open,
+            List<String> requires,
+            List<Directive> exports,
+            List<Directive> opens,
+            Set<String> packages) {
         this.name = name;
         this.open = open;
-        // Defensive copies: decouple from the caller's lists so this view stays truly immutable
-        // (List.copyOf would be simpler but is Java 9+; this class compiles with --release 8).
+        // Defensive copies: decouple from the caller's collections so this view stays truly immutable
+        // (List.copyOf/Set.copyOf would be simpler but are Java 9+; this class compiles with --release 8).
         this.requires = Collections.unmodifiableList(new ArrayList<>(requires));
         this.exports = Collections.unmodifiableList(new ArrayList<>(exports));
         this.opens = Collections.unmodifiableList(new ArrayList<>(opens));
+        this.packages = Collections.unmodifiableSet(new HashSet<>(packages));
     }
 
     /** The module name, such as {@code com.example.foo}. */
@@ -71,6 +82,19 @@ final class JavaModuleInfo {
     /** {@code opens} directives. */
     List<Directive> opens() {
         return opens;
+    }
+
+    /**
+     * All packages of the module, as reported by {@code ModuleDescriptor.packages()}.
+     *
+     * <p>Complete when the descriptor comes from a packaged artifact (the {@code ModulePackages}
+     * attribute is written at packaging time, and {@code ModuleFinder} falls back to scanning the
+     * artifact). For a bare {@code module-info.class} read from an output directory it may contain
+     * only the exported/opened packages — enumerate the directory instead when completeness
+     * matters there.</p>
+     */
+    Set<String> packages() {
+        return packages;
     }
 
     /** A single {@code exports}/{@code opens} directive: a package and its optional target modules. */

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads the {@code Module} attribute of a {@code module-info.class} (name, {@code requires},
+ * {@code exports}, {@code opens}) by delegating to {@link java.lang.module.ModuleDescriptor}.
+ *
+ * <p><b>Design decision.</b> This plugin compiles with {@code --release 8}, so it cannot
+ * reference {@code java.lang.module.ModuleDescriptor} (a Java&nbsp;9 API) directly. The obvious
+ * alternative — a multi-release JAR overlay ({@code src/main/java9}) so the module-reading code
+ * could be compiled for Java&nbsp;9 — is deliberately <em>not</em> used: multi-release JAR support
+ * in Maven&nbsp;3 is incomplete and can even produce invalid JARs (cf. MNG-6892 / MNG-6293 and
+ * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven&nbsp;4 (POM model 4.1.0 +
+ * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven&nbsp;3</b>
+ * and a Java&nbsp;8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
+ * through this small wrapper class: the API is present at runtime whenever a
+ * {@code module-info.class} exists (such a project is necessarily built on Java&nbsp;9+), and the
+ * rules simply do nothing when there is no module descriptor. See {@code apache/maven-enforcer#995}.
+ */
+final class JavaModuleInfoReader {
+
+    private static final String MODULE_DESCRIPTOR = "java.lang.module.ModuleDescriptor";
+    private static final String INVALID_DESCRIPTOR = "java.lang.module.InvalidModuleDescriptorException";
+
+    private JavaModuleInfoReader() {}
+
+    /**
+     * Parse a {@code module-info.class}.
+     *
+     * @param in the class-file bytes of a {@code module-info.class}
+     * @return the parsed module info, or {@code null} if the bytes are not a valid module descriptor
+     * @throws IOException if the bytes cannot be read, or if {@code java.lang.module} is unavailable
+     *                     (i.e. running on a Java&nbsp;8 runtime)
+     */
+    static JavaModuleInfo read(InputStream in) throws IOException {
+        byte[] classFile = readAllBytes(in);
+        // ModuleDescriptor.read cannot parse a class file newer than the running JVM; without this
+        // check it would throw InvalidModuleDescriptorException and we would wrongly treat the module
+        // as "not present". Surface a clear diagnostic instead.
+        checkReadableVersion(classFile);
+        try {
+            Class<?> descriptorType = Class.forName(MODULE_DESCRIPTOR);
+            Object descriptor = descriptorType
+                    .getMethod("read", InputStream.class)
+                    .invoke(null, new ByteArrayInputStream(classFile));
+
+            String name = (String) descriptorType.getMethod("name").invoke(descriptor);
+            boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
+            List<String> requires = requireNames(descriptor, descriptorType);
+            List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
+            List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
+            return new JavaModuleInfo(name, open, requires, exports, opens);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause != null && INVALID_DESCRIPTOR.equals(cause.getClass().getName())) {
+                return null; // not a valid module-info.class
+            }
+            throw new IOException("Could not read module descriptor", cause != null ? cause : e);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new IOException(
+                    "java.lang.module is not available; reading module-info requires a Java 9+ runtime", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("Could not read module descriptor", e);
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream in) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int read;
+        while ((read = in.read(chunk)) != -1) {
+            buffer.write(chunk, 0, read);
+        }
+        return buffer.toByteArray();
+    }
+
+    /**
+     * Fail fast if the {@code module-info.class} was built for a newer Java release than the JVM
+     * running the enforcer, in which case {@code ModuleDescriptor.read} cannot parse it.
+     */
+    private static void checkReadableVersion(byte[] classFile) throws IOException {
+        if (classFile.length < 8
+                || (classFile[0] & 0xFF) != 0xCA
+                || (classFile[1] & 0xFF) != 0xFE
+                || (classFile[2] & 0xFF) != 0xBA
+                || (classFile[3] & 0xFF) != 0xBE) {
+            throw new IOException("Not a Java class file (bad magic)");
+        }
+        int major = ((classFile[6] & 0xFF) << 8) | (classFile[7] & 0xFF);
+        int runtimeMajor = runtimeClassFileMajor();
+        if (major > runtimeMajor) {
+            throw new IOException("module-info.class has class file version " + major + " (Java " + (major - 44)
+                    + "), which is newer than the JVM running the enforcer (class file version " + runtimeMajor
+                    + ", Java " + (runtimeMajor - 44) + "). Run the build on that Java release or newer.");
+        }
+    }
+
+    /** The class-file major version of the running JVM (e.g. 52 for Java&nbsp;8, 69 for Java&nbsp;25). */
+    private static int runtimeClassFileMajor() {
+        // "java.class.version" is "52.0", "61.0", "69.0", ... — available since Java 1.1.
+        String version = System.getProperty("java.class.version", "52.0");
+        int dot = version.indexOf('.');
+        return Integer.parseInt(dot >= 0 ? version.substring(0, dot) : version);
+    }
+
+    private static List<String> requireNames(Object descriptor, Class<?> descriptorType)
+            throws ReflectiveOperationException {
+        Set<?> requires = (Set<?>) descriptorType.getMethod("requires").invoke(descriptor);
+        Method name = Class.forName(MODULE_DESCRIPTOR + "$Requires").getMethod("name");
+        List<String> result = new ArrayList<String>(requires.size());
+        for (Object require : requires) {
+            result.add((String) name.invoke(require));
+        }
+        return result;
+    }
+
+    private static List<JavaModuleInfo.Directive> directives(
+            Object descriptor, Class<?> descriptorType, String accessor, String innerType)
+            throws ReflectiveOperationException {
+        Set<?> entries = (Set<?>) descriptorType.getMethod(accessor).invoke(descriptor);
+        Class<?> entryType = Class.forName(MODULE_DESCRIPTOR + "$" + innerType);
+        Method source = entryType.getMethod("source");
+        Method targets = entryType.getMethod("targets");
+        List<JavaModuleInfo.Directive> result = new ArrayList<JavaModuleInfo.Directive>(entries.size());
+        for (Object entry : entries) {
+            String pkg = (String) source.invoke(entry);
+            Set<?> to = (Set<?>) targets.invoke(entry); // empty for an unqualified directive
+            List<String> moduleTargets = new ArrayList<String>(to.size());
+            for (Object target : to) {
+                moduleTargets.add((String) target);
+            }
+            result.add(new JavaModuleInfo.Directive(pkg, moduleTargets));
+        }
+        return result;
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Reads the {@code Module} attribute of a {@code module-info.class} (name, {@code requires},
@@ -72,13 +73,7 @@ final class JavaModuleInfoReader {
             Object descriptor = descriptorType
                     .getMethod("read", InputStream.class)
                     .invoke(null, new ByteArrayInputStream(classFile));
-
-            String name = (String) descriptorType.getMethod("name").invoke(descriptor);
-            boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
-            List<String> requires = requireNames(descriptor, descriptorType);
-            List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
-            List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
-            return new JavaModuleInfo(name, open, requires, exports, opens);
+            return fromDescriptor(descriptor);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause != null && INVALID_DESCRIPTOR.equals(cause.getClass().getName())) {
@@ -91,6 +86,21 @@ final class JavaModuleInfoReader {
         } catch (ReflectiveOperationException e) {
             throw new IOException("Could not read module descriptor", e);
         }
+    }
+
+    /**
+     * Map an already-obtained {@code java.lang.module.ModuleDescriptor} instance (accessed
+     * reflectively, e.g. from a {@code ModuleFinder}) to a {@link JavaModuleInfo}.
+     */
+    static JavaModuleInfo fromDescriptor(Object descriptor) throws ReflectiveOperationException {
+        Class<?> descriptorType = Class.forName(MODULE_DESCRIPTOR);
+        String name = (String) descriptorType.getMethod("name").invoke(descriptor);
+        boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
+        List<String> requires = requireNames(descriptor, descriptorType);
+        List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
+        List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
+        Set<String> packages = packageNames(descriptor, descriptorType);
+        return new JavaModuleInfo(name, open, requires, exports, opens, packages);
     }
 
     private static byte[] readAllBytes(InputStream in) throws IOException {
@@ -130,6 +140,16 @@ final class JavaModuleInfoReader {
         String version = System.getProperty("java.class.version", "52.0");
         int dot = version.indexOf('.');
         return Integer.parseInt(dot >= 0 ? version.substring(0, dot) : version);
+    }
+
+    private static Set<String> packageNames(Object descriptor, Class<?> descriptorType)
+            throws ReflectiveOperationException {
+        Set<?> packages = (Set<?>) descriptorType.getMethod("packages").invoke(descriptor);
+        Set<String> result = new TreeSet<String>();
+        for (Object packageName : packages) {
+            result.add((String) packageName);
+        }
+        return result;
     }
 
     private static List<String> requireNames(Object descriptor, Class<?> descriptorType)

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -138,6 +140,8 @@ final class JavaModuleInfoReader {
         for (Object require : requires) {
             result.add((String) name.invoke(require));
         }
+        // ModuleDescriptor#requires() is a Set: sort for stable diagnostics across JDKs
+        Collections.sort(result);
         return result;
     }
 
@@ -156,8 +160,11 @@ final class JavaModuleInfoReader {
             for (Object target : to) {
                 moduleTargets.add((String) target);
             }
+            // targets and directives come from Sets: sort for stable diagnostics across JDKs
+            Collections.sort(moduleTargets);
             result.add(new JavaModuleInfo.Directive(pkg, moduleTargets));
         }
+        result.sort(Comparator.comparing(JavaModuleInfo.Directive::packageName));
         return result;
     }
 }

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Reads the {@code Module} attribute of a {@code module-info.class} (name, {@code requires},
@@ -72,13 +73,7 @@ final class JavaModuleInfoReader {
             Object descriptor = descriptorType
                     .getMethod("read", InputStream.class)
                     .invoke(null, new ByteArrayInputStream(classFile));
-
-            String name = (String) descriptorType.getMethod("name").invoke(descriptor);
-            boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
-            List<String> requires = requireNames(descriptor, descriptorType);
-            List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
-            List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
-            return new JavaModuleInfo(name, open, requires, exports, opens);
+            return fromDescriptor(descriptor);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause != null && INVALID_DESCRIPTOR.equals(cause.getClass().getName())) {
@@ -91,6 +86,21 @@ final class JavaModuleInfoReader {
         } catch (ReflectiveOperationException e) {
             throw new IOException("Could not read module descriptor", e);
         }
+    }
+
+    /**
+     * Map an already-obtained {@code java.lang.module.ModuleDescriptor} instance (accessed
+     * reflectively, e.g. from a {@code ModuleFinder}) to a {@link JavaModuleInfo}.
+     */
+    static JavaModuleInfo fromDescriptor(Object descriptor) throws ReflectiveOperationException {
+        Class<?> descriptorType = Class.forName(MODULE_DESCRIPTOR);
+        String name = (String) descriptorType.getMethod("name").invoke(descriptor);
+        boolean open = (Boolean) descriptorType.getMethod("isOpen").invoke(descriptor);
+        List<String> requires = requireNames(descriptor, descriptorType);
+        List<JavaModuleInfo.Directive> exports = directives(descriptor, descriptorType, "exports", "Exports");
+        List<JavaModuleInfo.Directive> opens = directives(descriptor, descriptorType, "opens", "Opens");
+        Set<String> packages = packageNames(descriptor, descriptorType);
+        return new JavaModuleInfo(name, open, requires, exports, opens, packages);
     }
 
     // Hand-rolled drain: InputStream.readAllBytes() would do this in one call but is Java 9+,
@@ -132,6 +142,16 @@ final class JavaModuleInfoReader {
         String version = System.getProperty("java.class.version", "52.0");
         int dot = version.indexOf('.');
         return Integer.parseInt(dot >= 0 ? version.substring(0, dot) : version);
+    }
+
+    private static Set<String> packageNames(Object descriptor, Class<?> descriptorType)
+            throws ReflectiveOperationException {
+        Set<?> packages = (Set<?>) descriptorType.getMethod("packages").invoke(descriptor);
+        Set<String> result = new TreeSet<String>();
+        for (Object packageName : packages) {
+            result.add((String) packageName);
+        }
+        return result;
     }
 
     private static List<String> requireNames(Object descriptor, Class<?> descriptorType)

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReader.java
@@ -35,15 +35,15 @@ import java.util.Set;
  * {@code exports}, {@code opens}) by delegating to {@link java.lang.module.ModuleDescriptor}.
  *
  * <p><b>Design decision.</b> This plugin compiles with {@code --release 8}, so it cannot
- * reference {@code java.lang.module.ModuleDescriptor} (a Java&nbsp;9 API) directly. The obvious
+ * reference {@code java.lang.module.ModuleDescriptor} (a Java 9 API) directly. The obvious
  * alternative — a multi-release JAR overlay ({@code src/main/java9}) so the module-reading code
- * could be compiled for Java&nbsp;9 — is deliberately <em>not</em> used: multi-release JAR support
- * in Maven&nbsp;3 is incomplete and can even produce invalid JARs (cf. MNG-6892 / MNG-6293 and
- * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven&nbsp;4 (POM model 4.1.0 +
- * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven&nbsp;3</b>
- * and a Java&nbsp;8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
+ * could be compiled for Java 9 — is deliberately <em>not</em> used: multi-release JAR support
+ * in Maven 3 is incomplete and can even produce invalid JARs (see MNG-6892 / MNG-6293 and
+ * {@code maven-jar-plugin#484}); it is only cleanly solved in Maven 4 (POM model 4.1.0 +
+ * {@code maven-compiler-plugin} 4.0.0-beta-3). To keep these rules usable on <b>Maven 3</b>
+ * and a Java 8 source baseline, we instead access {@code ModuleDescriptor} <b>reflectively</b>
  * through this small wrapper class: the API is present at runtime whenever a
- * {@code module-info.class} exists (such a project is necessarily built on Java&nbsp;9+), and the
+ * {@code module-info.class} exists (such a project is necessarily built on Java 9+), and the
  * rules simply do nothing when there is no module descriptor. See {@code apache/maven-enforcer#995}.
  */
 final class JavaModuleInfoReader {
@@ -59,7 +59,7 @@ final class JavaModuleInfoReader {
      * @param in the class-file bytes of a {@code module-info.class}
      * @return the parsed module info, or {@code null} if the bytes are not a valid module descriptor
      * @throws IOException if the bytes cannot be read, or if {@code java.lang.module} is unavailable
-     *                     (i.e. running on a Java&nbsp;8 runtime)
+     *                     because the enforcer is running on a Java 8 runtime
      */
     static JavaModuleInfo read(InputStream in) throws IOException {
         byte[] classFile = readAllBytes(in);
@@ -93,6 +93,8 @@ final class JavaModuleInfoReader {
         }
     }
 
+    // Hand-rolled drain: InputStream.readAllBytes() would do this in one call but is Java 9+,
+    // and this class compiles with --release 8 (see the class javadoc).
     private static byte[] readAllBytes(InputStream in) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         byte[] chunk = new byte[8192];
@@ -113,7 +115,7 @@ final class JavaModuleInfoReader {
                 || (classFile[1] & 0xFF) != 0xFE
                 || (classFile[2] & 0xFF) != 0xBA
                 || (classFile[3] & 0xFF) != 0xBE) {
-            throw new IOException("Not a Java class file (bad magic)");
+            throw new IOException("Not a Java class file (bad magic number)");
         }
         int major = ((classFile[6] & 0xFF) << 8) | (classFile[7] & 0xFF);
         int runtimeMajor = runtimeClassFileMajor();
@@ -124,7 +126,7 @@ final class JavaModuleInfoReader {
         }
     }
 
-    /** The class-file major version of the running JVM (e.g. 52 for Java&nbsp;8, 69 for Java&nbsp;25). */
+    /** The class-file major version of the running JVM (such as 52 for Java 8, 69 for Java 25). */
     private static int runtimeClassFileMajor() {
         // "java.class.version" is "52.0", "61.0", "69.0", ... — available since Java 1.1.
         String version = System.getProperty("java.class.version", "52.0");

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Requires that a project with compiled classes is an <em>explicit</em> Java module, i.e. that its
+ * main output contains a {@code module-info.class}. This prevents a modular application from silently
+ * consuming a dependency as an <em>automatic module</em> (a plain JAR placed on the module path),
+ * whose auto-derived name and "exports everything" semantics are unstable across releases.
+ *
+ * <p>The rule does nothing for projects that compile no classes (e.g. {@code pom} aggregators or a
+ * module that only carries resources), so it can be enabled ecosystem-wide without special-casing.
+ * In a Maven&nbsp;4 module source hierarchy every per-module output directory is checked.
+ */
+@Named("requireExplicitModules")
+public final class RequireExplicitModules extends AbstractModuleInfoRule {
+
+    @Inject
+    public RequireExplicitModules(MavenProject project) {
+        super(project);
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        List<String> violations = new ArrayList<>();
+        for (ModuleOutput output : moduleOutputs()) {
+            if (output.moduleInfo() != null) {
+                continue;
+            }
+            if (!hasCompiledClasses(output.root())) {
+                getLog().debug("No compiled classes in " + output.root() + "; skipping " + ruleName());
+                continue;
+            }
+            violations.add(output.root().getPath());
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Project '" + project.getArtifactId() + "' is not an explicit Java module: no "
+                                    + "module-info.class in " + String.join(", ", violations)
+                                    + ". Add a module-info.java so the "
+                                    + "artifact is a named module and never resolves as an automatic module.");
+        }
+    }
+
+    /** {@code true} if the output directory holds at least one compiled class other than the module descriptor. */
+    private static boolean hasCompiledClasses(File outputDirectory) throws EnforcerRuleException {
+        Path root = outputDirectory.toPath();
+        if (!Files.isDirectory(root)) {
+            return false;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths.filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .anyMatch(name -> name.endsWith(".class") && !name.equals("module-info.class"));
+        } catch (UncheckedIOException | IOException e) {
+            throw new EnforcerRuleException("Failed to scan " + outputDirectory + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RequireExplicitModules[message=%s]", getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModules.java
@@ -34,14 +34,14 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.project.MavenProject;
 
 /**
- * Requires that a project with compiled classes is an <em>explicit</em> Java module, i.e. that its
- * main output contains a {@code module-info.class}. This prevents a modular application from silently
- * consuming a dependency as an <em>automatic module</em> (a plain JAR placed on the module path),
- * whose auto-derived name and "exports everything" semantics are unstable across releases.
+ * Requires that a project with compiled classes is an <em>explicit</em> Java module. Its main output
+ * must contain a {@code module-info.class}. This prevents a modular application from silently consuming
+ * a dependency as an <em>automatic module</em> (a plain JAR placed on the module path). Such a module's
+ * auto-derived name and "exports everything" semantics are unstable across releases.
  *
- * <p>The rule does nothing for projects that compile no classes (e.g. {@code pom} aggregators or a
+ * <p>The rule does nothing for projects that compile no classes (such as {@code pom} aggregators or a
  * module that only carries resources), so it can be enabled ecosystem-wide without special-casing.
- * In a Maven&nbsp;4 module source hierarchy every per-module output directory is checked.
+ * In a Maven 4 module source hierarchy every per-module output directory is checked.
  */
 @Named("requireExplicitModules")
 public final class RequireExplicitModules extends AbstractModuleInfoRule {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -60,7 +60,7 @@ public final class RequireMinimalExports extends AbstractModuleInfoRule {
     }
 
     public void setAllowedExports(List<String> allowedExports) {
-        this.allowedExports = allowedExports;
+        this.allowedExports = allowedExports != null ? allowedExports : new ArrayList<>();
     }
 
     public void setIgnoreQualifiedExports(boolean ignoreQualifiedExports) {

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Keeps a module's public surface minimal by banning {@code exports} of packages that are meant to be
+ * internal. By default any package whose name has an {@code internal} or {@code impl} segment (e.g.
+ * {@code com.example.foo.internal} or {@code com.example.impl.util}) must not be exported; the set is
+ * configurable through {@code <internalPackagePattern>}.
+ *
+ * <p>Qualified exports ({@code exports a.b.c to some.friend;}) are ignored by default, because naming
+ * the consumer is a deliberate, reviewable decision; set {@code <ignoreQualifiedExports>false</ignoreQualifiedExports>}
+ * to check them too. Individual packages can be whitelisted through {@code <allowedExports>}.
+ */
+@Named("requireMinimalExports")
+public final class RequireMinimalExports extends AbstractModuleInfoRule {
+
+    /** Regex matching packages considered non-API; a match that is exported fails the build. */
+    private String internalPackagePattern = ".*\\.(internal|impl)(\\..*)?";
+
+    /** Packages exempt from the check even if they match {@link #internalPackagePattern}. */
+    private List<String> allowedExports = new ArrayList<>();
+
+    /** When {@code true} (default), only unqualified {@code exports} are checked. */
+    private boolean ignoreQualifiedExports = true;
+
+    @Inject
+    public RequireMinimalExports(MavenProject project) {
+        super(project);
+    }
+
+    public void setInternalPackagePattern(String internalPackagePattern) {
+        this.internalPackagePattern = internalPackagePattern;
+    }
+
+    public void setAllowedExports(List<String> allowedExports) {
+        this.allowedExports = allowedExports;
+    }
+
+    public void setIgnoreQualifiedExports(boolean ignoreQualifiedExports) {
+        this.ignoreQualifiedExports = ignoreQualifiedExports;
+    }
+
+    @Override
+    public void execute() throws EnforcerRuleException {
+        Pattern internal = Pattern.compile(internalPackagePattern);
+        for (ModuleOutput output : moduleOutputs()) {
+            JavaModuleInfo module = output.moduleInfo();
+            if (module == null) {
+                continue;
+            }
+            checkModule(module, internal);
+        }
+    }
+
+    private void checkModule(JavaModuleInfo module, Pattern internal) throws EnforcerRuleException {
+        List<String> violations = new ArrayList<>();
+        for (JavaModuleInfo.Directive export : module.exports()) {
+            if (ignoreQualifiedExports && export.isQualified()) {
+                continue;
+            }
+            String packageName = export.packageName();
+            if (!allowedExports.contains(packageName)
+                    && internal.matcher(packageName).matches()) {
+                violations.add(packageName);
+            }
+        }
+        if (!violations.isEmpty()) {
+            String message = getMessage();
+            throw new EnforcerRuleException(
+                    message != null
+                            ? message
+                            : "Module " + module.name() + " exports internal package(s) " + violations + " matching '"
+                                    + internalPackagePattern
+                                    + "'. Keep exports to public API packages, or whitelist them "
+                                    + "in <allowedExports>.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "RequireMinimalExports[internalPackagePattern=%s, ignoreQualifiedExports=%b, allowedExports=%s, message=%s]",
+                internalPackagePattern, ignoreQualifiedExports, allowedExports, getMessage());
+    }
+}

--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExports.java
@@ -30,7 +30,7 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Keeps a module's public surface minimal by banning {@code exports} of packages that are meant to be
- * internal. By default any package whose name has an {@code internal} or {@code impl} segment (e.g.
+ * internal. By default any package whose name has an {@code internal} or {@code impl} segment (such as
  * {@code com.example.foo.internal} or {@code com.example.impl.util}) must not be exported; the set is
  * configurable through {@code <internalPackagePattern>}.
  *

--- a/enforcer-rules/src/site/apt/banSplitPackages.apt.vm
+++ b/enforcer-rules/src/site/apt/banSplitPackages.apt.vm
@@ -1,0 +1,112 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Ban Split Packages
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-17
+  ------
+
+Ban Split Packages
+
+  A package must belong to exactly one Java module. Two modules on the module path containing the same
+  package form an illegal <split package> that the boot layer rejects at resolution
+  (<<<java.lang.module.ResolutionException>>>) — and if the offending module happens not to be
+  <<<requires>>>d, the resolver never pulls it in: the build stays green while a type or endpoint is
+  silently absent at runtime. Split packages are typically introduced by accident: a build-time code
+  generator, a shaded or unpacked dependency, or a copied resource placing classes of a <foreign>
+  package into the project's output.
+
+  This rule intersects the package sets of the project's compiled output(s) and of <<every>> declared
+  dependency — deliberately not only the <<<requires>>>d modules, which is exactly what catches the
+  silent variant. Overlaps between two modules that would both end up on the module path fail the
+  build; overlaps involving a plain classpath artifact are legal today and are reported at
+  <<<classpathSeverity>>> (default <<<warn>>>) as a modularization hazard. An automatic module counts
+  as being on the module path only when the project actually <<<requires>>> its derived name.
+
+  The rule is a safety net, not a fix — the durable cure is placing generated or copied classes in the
+  module that owns their package.
+
+* Reading the compiled output
+
+  The project's packages are determined by walking <<<$\{project.build.outputDirectory\}>>> for compiled
+  classes (not from the module descriptor, whose package list is only finalized at packaging time —
+  offending classes are frequently added <after> compilation). The <<<enforce>>> execution must therefore
+  run <<after>> compilation: bind it to a phase such as <<<process-classes>>> (the default
+  <<<validate>>> phase runs before <<<compile>>>).
+
+  Both output layouts are supported: the classic one (one Maven project = one Java module) and the
+  Maven 4 <module source hierarchy> (POM model 4.1.0), where one Maven project compiles several
+  modules, each to its own subdirectory <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+  Dependency packages are read through <<<java.lang.module.ModuleFinder>>>, which handles automatic
+  modules transparently.
+
+  The following parameters are supported by this rule:
+
+   * <<classpathSeverity>> - severity for overlaps involving an artifact that is not on the module
+     path: <<<warn>>> (default), <<<error>>> or <<<ignore>>>. Such overlaps are legal on the classpath
+     today, but break a later migration to the module path.
+
+   * <<allowedSplitPackages>> - a list of package names permitted to overlap.
+
+   * <<ignoredModules>> - a list of module names whose artifacts are excluded from the check.
+
+   * <<ignoredArtifacts>> - a list of dependencies excluded from the check, as
+     <<<groupId:artifactId>>>.
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-split-packages</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banSplitPackages>
+                  <classpathSeverity>error</classpathSeverity>
+                  <allowedSplitPackages>
+                    <allowedSplitPackage>com.example.legacy.shared</allowedSplitPackage>
+                  </allowedSplitPackages>
+                </banSplitPackages>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/banUnjustifiedOpens.apt.vm
+++ b/enforcer-rules/src/site/apt/banUnjustifiedOpens.apt.vm
@@ -1,0 +1,89 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Ban Unjustified Opens
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Ban Unjustified Opens
+
+  This rule bans unqualified deep-reflection access into a Java module. A bare <<<opens a.b.c;>>> (or an
+  <<<open module>>>) grants <every> other module reflective access to a package's private members, which defeats
+  strong encapsulation. A framework that needs reflective access should be named explicitly with a qualified
+  <<<opens a.b.c to some.framework;>>>.
+
+  Packages that genuinely must be opened to the whole world can be listed in <<<allowedOpens>>> to pass the check.
+  The rule does nothing for non-modular projects (no <<<module-info.class>>>).
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<allowedOpens>> - a list of package names that are allowed to be opened unqualifiedly despite the ban.
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-unjustified-opens</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banUnjustifiedOpens>
+                  <allowedOpens>
+                    <allowedOpen>com.example.foo.dto</allowedOpen>
+                  </allowedOpens>
+                </banUnjustifiedOpens>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -47,6 +47,8 @@ Built-In Rules
 
   * {{{./banTransitiveDependencies.html}banTransitiveDependencies}} - enforces that project doesn't have transitive dependencies.
 
+  * {{{./banUnjustifiedOpens.html}banUnjustifiedOpens}} - bans unqualified <<<opens>>> (and <<<open module>>>) in a Java module.
+
   * {{{./dependencyConvergence.html}dependencyConvergence}} - ensure all dependencies converge to the same version.
 
   * {{{./enforceBytecodeVersion.html}enforceBytecodeVersion}} - enforces that dependency bytecode versions do not exceed the configured maximum.
@@ -63,6 +65,8 @@ Built-In Rules
 
   * {{{./requireExplicitDependencyScope.html}requireExplicitDependencyScope}} - enforces that all dependencies have an explicit scope.
 
+  * {{{./requireExplicitModules.html}requireExplicitModules}} - enforces that a project with compiled classes is an explicit Java module.
+
   * {{{./requireFileChecksum.html}requireFileChecksum}} - enforces that the specified file has a certain checksum.
   
   * {{{./requireFilesDontExist.html}requireFilesDontExist}} - enforces that the list of files does not exist.
@@ -78,6 +82,8 @@ Built-In Rules
   * {{{./requireMatchingCoordinates.html}requireMatchingCoordinates}} - enforces specific group ID and/or artifact ID patterns.
 
   * {{{./requireMavenVersion.html}requireMavenVersion}} - enforces the Maven version.
+
+  * {{{./requireMinimalExports.html}requireMinimalExports}} - enforces that a Java module does not export internal packages.
 
   * {{{./requireNoRepositories.html}requireNoRepositories}} - enforces to not include repositories.
 

--- a/enforcer-rules/src/site/apt/index.apt
+++ b/enforcer-rules/src/site/apt/index.apt
@@ -45,6 +45,8 @@ Built-In Rules
   
   * {{{./bannedRepositories.html}bannedRepositories}} - enforces to not include banned repositories.
 
+  * {{{./banSplitPackages.html}banSplitPackages}} - bans packages contained in more than one Java module (split packages).
+
   * {{{./banTransitiveDependencies.html}banTransitiveDependencies}} - enforces that project doesn't have transitive dependencies.
 
   * {{{./banUnjustifiedOpens.html}banUnjustifiedOpens}} - bans unqualified <<<opens>>> (and <<<open module>>>) in a Java module.

--- a/enforcer-rules/src/site/apt/requireExplicitModules.apt.vm
+++ b/enforcer-rules/src/site/apt/requireExplicitModules.apt.vm
@@ -1,0 +1,83 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Require Explicit Modules
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Require Explicit Modules
+
+  This rule requires that a project which compiles classes is an <explicit> Java module, i.e. that its main
+  output contains a <<<module-info.class>>>. This prevents a modular application from silently consuming the
+  artifact as an <automatic module> (a plain JAR placed on the module path), whose auto-derived name and
+  "exports everything" semantics are unstable across releases.
+
+  The rule does nothing for projects that compile no classes (e.g. <<<pom>>> aggregators, or a module that only
+  carries resources), so it can be enabled across a whole build without special-casing.
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-explicit-modules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireExplicitModules/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/apt/requireMinimalExports.apt.vm
+++ b/enforcer-rules/src/site/apt/requireMinimalExports.apt.vm
@@ -1,0 +1,95 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Require Minimal Exports
+  ------
+  Gerd Aschemann
+  ------
+  2026-07-16
+  ------
+
+Require Minimal Exports
+
+  This rule keeps a Java module's public surface minimal by banning <<<exports>>> of packages that are meant to be
+  internal. By default any package whose name has an <<<internal>>> or <<<impl>>> segment (e.g.
+  <<<com.example.foo.internal>>> or <<<com.example.impl.util>>>) must not be exported.
+
+  Qualified exports (<<<exports a.b.c to some.friend;>>>) are ignored by default, because naming the consumer is a
+  deliberate, reviewable decision. The rule does nothing for non-modular projects (no <<<module-info.class>>>).
+
+* Reading the module descriptor
+
+  This rule inspects the compiled <<<module-info.class>>> under <<<$\{project.build.outputDirectory\}>>>, so its
+  <<<enforce>>> execution must run <<after>> compilation. Bind it to a phase such as <<<process-classes>>>
+  (the default <<<validate>>> phase runs before <<<compile>>>, when no <<<module-info.class>>> exists yet).
+
+  Both output layouts are supported: the classic one (the descriptor directly in the output directory, one
+  Maven project = one Java module) and the Maven 4 <module source hierarchy> (POM model 4.1.0), where one
+  Maven project compiles several modules, each to its own subdirectory
+  <<<$\{project.build.outputDirectory\}/<module-name>/>>>.
+
+  The following parameters are supported by this rule:
+
+   * <<internalPackagePattern>> - a regular expression matching packages considered non-API. An exported package
+     that matches fails the build. Default is <<<.*\\.(internal|impl)(\\..*)?>>>.
+
+   * <<allowedExports>> - a list of package names that are exempt from the check even if they match
+     <<<internalPackagePattern>>>.
+
+   * <<ignoreQualifiedExports>> - if <<<true>>> (default) only unqualified <<<exports>>> are checked; set to
+     <<<false>>> to also check qualified <<<exports ... to>>> directives.
+
+   * <<message>> - an optional message to the user if the rule fails.
+
+   []
+
+  Sample Plugin Configuration:
+
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-minimal-exports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireMinimalExports>
+                  <allowedExports>
+                    <allowedExport>com.example.foo.internal.api</allowedExport>
+                  </allowedExports>
+                </requireMinimalExports>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+

--- a/enforcer-rules/src/site/markdown/banSplitPackages.md.vm
+++ b/enforcer-rules/src/site/markdown/banSplitPackages.md.vm
@@ -1,0 +1,88 @@
+---
+title: Ban Split Packages
+author:
+  - Gerd Aschemann
+date: 2026-07-17
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Ban Split Packages
+
+A package must belong to exactly one Java module. Two modules on the module path containing the same package form an illegal *split package* that the boot layer rejects at resolution (`java.lang.module.ResolutionException`) — and if the offending module happens not to be `requires`d, the resolver never pulls it in: the build stays green while a type or endpoint is silently absent at runtime. Split packages are typically introduced by accident: a build-time code generator, a shaded or unpacked dependency, or a copied resource placing classes of a *foreign* package into the project's output.
+
+This rule intersects the package sets of the project's compiled output(s) and of **every** declared dependency — deliberately not only the `requires`d modules, which is exactly what catches the silent variant. Overlaps between two modules that would both end up on the module path fail the build; overlaps involving a plain classpath artifact are legal today and are reported at `classpathSeverity` (default `warn`) as a modularization hazard. An automatic module counts as being on the module path only when the project actually `requires` its derived name.
+
+The rule is a safety net, not a fix — the durable cure is placing generated or copied classes in the module that owns their package.
+
+## Reading the compiled output
+
+The project's packages are determined by walking `\${project.build.outputDirectory}` for compiled classes (not from the module descriptor, whose package list is only finalized at packaging time — offending classes are frequently added *after* compilation). The `enforce` execution must therefore run *after* compilation: bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`).
+
+Both output layouts are supported: the classic one (one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`. Dependency packages are read through `java.lang.module.ModuleFinder`, which handles automatic modules transparently.
+
+The following parameters are supported by this rule:
+
+- **classpathSeverity** - severity for overlaps involving an artifact that is not on the module path: `warn` (default), `error` or `ignore`. Such overlaps are legal on the classpath today, but break a later migration to the module path.
+
+- **allowedSplitPackages** - a list of package names permitted to overlap.
+
+- **ignoredModules** - a list of module names whose artifacts are excluded from the check.
+
+- **ignoredArtifacts** - a list of dependencies excluded from the check, as `groupId:artifactId`.
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-split-packages</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banSplitPackages>
+                  <classpathSeverity>error</classpathSeverity>
+                  <allowedSplitPackages>
+                    <allowedSplitPackage>com.example.legacy.shared</allowedSplitPackage>
+                  </allowedSplitPackages>
+                </banSplitPackages>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/site/markdown/banUnjustifiedOpens.md.vm
+++ b/enforcer-rules/src/site/markdown/banUnjustifiedOpens.md.vm
@@ -1,0 +1,79 @@
+---
+title: Ban Unjustified Opens
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Ban Unjustified Opens
+
+This rule bans unqualified deep-reflection access into a Java module. A bare `opens a.b.c;` (or an `open module`) grants *every* other module reflective access to a package's private members, which defeats strong encapsulation. A framework that needs reflective access should be named explicitly with a qualified `opens a.b.c to some.framework;`.
+
+Packages that genuinely must be opened to the whole world can be listed in `allowedOpens` to pass the check. The rule does nothing for non-modular projects (no `module-info.class`).
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **allowedOpens** - a list of package names that are allowed to be opened unqualifiedly despite the ban.
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>ban-unjustified-opens</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <banUnjustifiedOpens>
+                  <allowedOpens>
+                    <allowedOpen>com.example.foo.dto</allowedOpen>
+                  </allowedOpens>
+                </banUnjustifiedOpens>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/site/markdown/index.md
+++ b/enforcer-rules/src/site/markdown/index.md
@@ -37,6 +37,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [bannedDependencies](./bannedDependencies.html) - enforces that excluded dependencies aren't included.
 - [bannedPlugins](./bannedPlugins.html) - enforces that specific plugins aren't included in the build.
 - [bannedRepositories](./bannedRepositories.html) - enforces to not include banned repositories.
+- [banSplitPackages](./banSplitPackages.html) - bans packages contained in more than one Java module (split packages).
 - [banTransitiveDependencies](./banTransitiveDependencies.html) - enforces that project doesn't have transitive dependencies.
 - [banUnjustifiedOpens](./banUnjustifiedOpens.html) - bans unqualified `opens` (and `open module`) in a Java module.
 - [dependencyConvergence](./dependencyConvergence.html) - ensure all dependencies converge to the same version.

--- a/enforcer-rules/src/site/markdown/index.md
+++ b/enforcer-rules/src/site/markdown/index.md
@@ -38,6 +38,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [bannedPlugins](./bannedPlugins.html) - enforces that specific plugins aren't included in the build.
 - [bannedRepositories](./bannedRepositories.html) - enforces to not include banned repositories.
 - [banTransitiveDependencies](./banTransitiveDependencies.html) - enforces that project doesn't have transitive dependencies.
+- [banUnjustifiedOpens](./banUnjustifiedOpens.html) - bans unqualified `opens` (and `open module`) in a Java module.
 - [dependencyConvergence](./dependencyConvergence.html) - ensure all dependencies converge to the same version.
 - [enforceBytecodeVersion](./enforceBytecodeVersion.html) - enforces that dependency bytecode versions do not exceed the configured maximum.
 - [evaluateBeanshell](./evaluateBeanshell.html) - evaluates a beanshell script.
@@ -46,6 +47,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [requireActiveProfile](./requireActiveProfile.html) - enforces one or more active profiles.
 - [requireEnvironmentVariable](./requireEnvironmentVariable.html) - enforces the existence of an environment variable.
 - [requireExplicitDependencyScope](./requireExplicitDependencyScope.html) - enforces that all dependencies have an explicit scope.
+- [requireExplicitModules](./requireExplicitModules.html) - enforces that a project with compiled classes is an explicit Java module.
 - [requireFileChecksum](./requireFileChecksum.html) - enforces that the specified file has a certain checksum.
 - [requireFilesDontExist](./requireFilesDontExist.html) - enforces that the list of files does not exist.
 - [requireFilesExist](./requireFilesExist.html) - enforces that the list of files does exist.
@@ -54,6 +56,7 @@ The following built-in rules ship along with the enforcer plugin:
 - [requireJavaVersion](./requireJavaVersion.html) - enforces the JDK version.
 - [requireMatchingCoordinates](./requireMatchingCoordinates.html) - enforces specific group ID and/or artifact ID patterns.
 - [requireMavenVersion](./requireMavenVersion.html) - enforces the Maven version.
+- [requireMinimalExports](./requireMinimalExports.html) - enforces that a Java module does not export internal packages.
 - [requireNoRepositories](./requireNoRepositories.html) - enforces to not include repositories.
 - [requireOS](./requireOS.html) - enforces the OS / CPU Architecture.
 - [requirePluginVersions](./requirePluginVersions.html) - enforces that all plugins have a specified version.

--- a/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
+++ b/enforcer-rules/src/site/markdown/requireExplicitModules.md.vm
@@ -1,0 +1,73 @@
+---
+title: Require Explicit Modules
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Require Explicit Modules
+
+This rule requires that a project which compiles classes is an *explicit* Java module, i.e. that its main output contains a `module-info.class`. This prevents a modular application from silently consuming the artifact as an *automatic module* (a plain JAR placed on the module path), whose auto-derived name and "exports everything" semantics are unstable across releases.
+
+The rule does nothing for projects that compile no classes (e.g. `pom` aggregators, or a module that only carries resources), so it can be enabled across a whole build without special-casing.
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-explicit-modules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireExplicitModules/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/site/markdown/requireMinimalExports.md.vm
+++ b/enforcer-rules/src/site/markdown/requireMinimalExports.md.vm
@@ -1,0 +1,83 @@
+---
+title: Require Minimal Exports
+author:
+  - Gerd Aschemann
+date: 2026-07-16
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Require Minimal Exports
+
+This rule keeps a Java module's public surface minimal by banning `exports` of packages that are meant to be internal. By default any package whose name has an `internal` or `impl` segment (e.g. `com.example.foo.internal` or `com.example.impl.util`) must not be exported.
+
+Qualified exports (`exports a.b.c to some.friend;`) are ignored by default, because naming the consumer is a deliberate, reviewable decision. The rule does nothing for non-modular projects (no `module-info.class`).
+
+## Reading the module descriptor
+
+This rule inspects the compiled `module-info.class` under `\${project.build.outputDirectory}`, so its `enforce` execution must run *after* compilation. Bind it to a phase such as `process-classes` (the default `validate` phase runs before `compile`, when no `module-info.class` exists yet).
+
+Both output layouts are supported: the classic one (the descriptor directly in the output directory, one Maven project = one Java module) and the Maven 4 *module source hierarchy* (POM model 4.1.0), where one Maven project compiles several modules, each to its own subdirectory `\${project.build.outputDirectory}/<module-name>/`.
+
+The following parameters are supported by this rule:
+
+- **internalPackagePattern** - a regular expression matching packages considered non-API. An exported package that matches fails the build. Default is `.*\.(internal|impl)(\..*)?`.
+
+- **allowedExports** - a list of package names that are exempt from the check even if they match `internalPackagePattern`.
+
+- **ignoreQualifiedExports** - if `true` (default) only unqualified `exports` are checked; set to `false` to also check qualified `exports ... to` directives.
+
+- **message** - an optional message to the user if the rule fails.
+
+Sample Plugin Configuration:
+
+```xml
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <id>require-minimal-exports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <requireMinimalExports>
+                  <allowedExports>
+                    <allowedExport>com.example.foo.internal.api</allowedExport>
+                  </allowedExports>
+                </requireMinimalExports>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
+```

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanSplitPackagesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanSplitPackagesTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.dependency.ResolverUtil;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// Scans dependencies via java.lang.module.ModuleFinder, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class BanSplitPackagesTest {
+
+    @TempDir
+    File outputDirectory;
+
+    @TempDir
+    File dependencyDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private final ResolverUtil resolverUtil = mock(ResolverUtil.class);
+    private final EnforcerLogger log = mock(EnforcerLogger.class);
+    private BanSplitPackages rule;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new BanSplitPackages(project, resolverUtil);
+        rule.setLog(log);
+        dependencies(); // no dependencies unless a test sets some
+    }
+
+    private void dependencies(File... files) throws Exception {
+        DefaultDependencyNode root = new DefaultDependencyNode(new DefaultArtifact("test:project:1.0"));
+        List<DependencyNode> children = new ArrayList<>();
+        int index = 0;
+        for (File file : files) {
+            Artifact artifact = new DefaultArtifact("test:dep" + ++index + ":1.0").setFile(file);
+            children.add(new DefaultDependencyNode(new Dependency(artifact, "compile")));
+        }
+        root.setChildren(children);
+        when(resolverUtil.resolveTransitiveDependencies(anyBoolean(), anyBoolean(), anyBoolean(), anyList()))
+                .thenReturn(root);
+    }
+
+    private File modularDependency(String moduleName, String... classNames) throws Exception {
+        ModuleInfoFixtures.Builder builder = ModuleInfoFixtures.module(moduleName);
+        for (String className : classNames) {
+            builder.packages(className.substring(0, className.lastIndexOf('.')));
+        }
+        return ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, moduleName + ".jar"), builder.toBytes(), null, classNames);
+    }
+
+    private void modularProject(String... classNames) throws Exception {
+        ModuleInfoFixtures.module("com.example.app").writeTo(outputDirectory);
+        for (String className : classNames) {
+            ModuleInfoFixtures.writeDummyClass(outputDirectory, className);
+        }
+    }
+
+    @Test
+    void disjointPackagesPass() throws Exception {
+        modularProject("com.example.app.Main");
+        dependencies(modularDependency("com.acme.lib", "com.acme.lib.Util"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void overlapBetweenProjectModuleAndUnrequiredExplicitModuleFails() throws Exception {
+        // the silent variant: the project does not even `requires` the split module
+        modularProject("com.acme.shared.Copied", "com.example.app.Main");
+        dependencies(modularDependency("com.acme.lib", "com.acme.shared.Original"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.acme.shared"));
+        assertTrue(e.getMessage().contains("com.example.app"));
+        assertTrue(e.getMessage().contains("com.acme.lib"));
+    }
+
+    @Test
+    void overlapBetweenTwoExplicitDependencyModulesFails() throws Exception {
+        modularProject("com.example.app.Main");
+        dependencies(
+                modularDependency("com.acme.one", "com.acme.shared.A"),
+                modularDependency("com.acme.two", "com.acme.shared.B"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.acme.shared"));
+    }
+
+    @Test
+    void overlapWithRequiredAutomaticModuleFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.app").requires("acme.auto").writeTo(outputDirectory);
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.acme.shared.Copied");
+        dependencies(ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, "auto.jar"), null, "acme.auto", "com.acme.shared.Original"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("acme.auto"));
+    }
+
+    @Test
+    void overlapWithUnrequiredAutomaticModuleOnlyWarnsByDefault() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, "auto.jar"), null, "acme.auto", "com.acme.shared.Original"));
+        assertDoesNotThrow(rule::execute);
+        ArgumentCaptor<CharSequence> warning = ArgumentCaptor.forClass(CharSequence.class);
+        verify(log).warn(warning.capture());
+        assertTrue(warning.getValue().toString().contains("com.acme.shared"));
+    }
+
+    @Test
+    void overlapWithFilenameDerivedAutomaticModuleOnlyWarnsByDefault() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        // no manifest entry: the automatic name is derived from the file name ("plain")
+        dependencies(ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, "plain-1.0-SNAPSHOT.jar"), null, null, "com.acme.shared.Original"));
+        assertDoesNotThrow(rule::execute);
+        verify(log).warn(ArgumentCaptor.forClass(CharSequence.class).capture());
+    }
+
+    @Test
+    void overlapWithNonModularDirectoryDependencyOnlyWarnsByDefault() throws Exception {
+        // e.g. a reactor sibling resolved to its target/classes, without a module-info.class
+        modularProject("com.acme.shared.Copied");
+        File classesDirectory = new File(dependencyDirectory, "classes");
+        ModuleInfoFixtures.writeDummyClass(classesDirectory, "com.acme.shared.Original");
+        dependencies(classesDirectory);
+        assertDoesNotThrow(rule::execute);
+        ArgumentCaptor<CharSequence> warning = ArgumentCaptor.forClass(CharSequence.class);
+        verify(log).warn(warning.capture());
+        assertTrue(warning.getValue().toString().contains("com.acme.shared"));
+    }
+
+    @Test
+    void classpathSeverityErrorFailsOnUnrequiredAutomaticModule() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, "auto.jar"), null, "acme.auto", "com.acme.shared.Original"));
+        rule.setClasspathSeverity("error");
+        assertThrows(EnforcerRuleException.class, rule::execute);
+    }
+
+    @Test
+    void classpathSeverityIgnoreStaysSilent() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(ModuleInfoFixtures.writeJar(
+                new File(dependencyDirectory, "auto.jar"), null, "acme.auto", "com.acme.shared.Original"));
+        rule.setClasspathSeverity("ignore");
+        assertDoesNotThrow(rule::execute);
+        verify(log, never()).warn((CharSequence) org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void allowedSplitPackagesPass() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(modularDependency("com.acme.lib", "com.acme.shared.Original"));
+        rule.setAllowedSplitPackages(Arrays.asList("com.acme.shared"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void ignoredModulesPass() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(modularDependency("com.acme.lib", "com.acme.shared.Original"));
+        rule.setIgnoredModules(Arrays.asList("com.acme.lib"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void ignoredArtifactsPass() throws Exception {
+        modularProject("com.acme.shared.Copied");
+        dependencies(modularDependency("com.acme.lib", "com.acme.shared.Original"));
+        rule.setIgnoredArtifacts(Arrays.asList("test:dep1"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void moduleSourceHierarchyOverlapBetweenProjectModulesFails() throws Exception {
+        // Maven 4 module source hierarchy: one output directory per module
+        ModuleInfoFixtures.module("com.example.api").writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.writeDummyClass(new File(outputDirectory, "com.example.api"), "com.acme.shared.A");
+        ModuleInfoFixtures.module("com.example.core").writeTo(new File(outputDirectory, "com.example.core"));
+        ModuleInfoFixtures.writeDummyClass(new File(outputDirectory, "com.example.core"), "com.acme.shared.B");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.acme.shared"));
+        assertTrue(e.getMessage().contains("com.example.api"));
+        assertTrue(e.getMessage().contains("com.example.core"));
+    }
+
+    @Test
+    void invalidClasspathSeverityIsRejected() throws Exception {
+        rule.setClasspathSeverity("fatal");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("classpathSeverity"));
+    }
+
+    @Test
+    void nonModularProjectWithoutOverlapPasses() throws Exception {
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.app.Main");
+        dependencies(modularDependency("com.acme.lib", "com.acme.lib.Util"));
+        assertDoesNotThrow(rule::execute);
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpensTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/BanUnjustifiedOpensTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class BanUnjustifiedOpensTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private BanUnjustifiedOpens rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new BanUnjustifiedOpens(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void qualifiedOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.fasterxml.jackson.databind")
+                .opens("com.example.foo.dto", "com.fasterxml.jackson.databind")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void unqualifiedOpensFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .opens("com.example.foo.dto")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.foo.dto"), e.getMessage());
+    }
+
+    @Test
+    void whitelistedUnqualifiedOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .opens("com.example.foo.dto")
+                .writeTo(outputDirectory);
+        rule.setAllowedOpens(Arrays.asList("com.example.foo.dto"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anOpenModuleFails() throws Exception {
+        ModuleInfoFixtures.openModule("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("open module"), e.getMessage());
+    }
+
+    @Test
+    void aModuleWithoutOpensPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aNonModularProjectPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anUnqualifiedOpensInAModuleSourceHierarchyFails() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.cli")
+                .opens("com.example.cli")
+                .writeTo(new File(outputDirectory, "com.example.cli"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.cli"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReaderTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/JavaModuleInfoReaderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class JavaModuleInfoReaderTest {
+
+    /** Build a real {@code module-info.class} with ASM (test scope only). */
+    private static byte[] moduleInfo() {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        ModuleVisitor mv = cw.visitModule("com.example.foo", 0, null);
+        mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+        mv.visitRequire("com.example.bar", 0, null);
+        mv.visitExport("com/example/foo/api", 0); // unqualified
+        mv.visitExport("com/example/foo/internal", 0, "com.example.bar"); // qualified
+        mv.visitOpen("com/example/foo/impl", 0);
+        mv.visitEnd();
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    private static List<String> packages(List<JavaModuleInfo.Directive> directives) {
+        List<String> names = new ArrayList<String>();
+        for (JavaModuleInfo.Directive d : directives) {
+            names.add(d.packageName());
+        }
+        return names;
+    }
+
+    @Test
+    void readsModuleNameRequiresExportsAndOpens() throws Exception {
+        JavaModuleInfo m = JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()));
+
+        assertNotNull(m);
+        assertEquals("com.example.foo", m.name());
+
+        assertTrue(m.requires().contains("java.base"));
+        assertTrue(m.requires().contains("com.example.bar"));
+
+        List<String> exported = packages(m.exports());
+        assertTrue(exported.contains("com.example.foo.api"), "expected unqualified export");
+        assertTrue(exported.contains("com.example.foo.internal"), "expected qualified export");
+
+        assertEquals(1, m.opens().size());
+        assertEquals("com.example.foo.impl", m.opens().get(0).packageName());
+    }
+
+    @Test
+    void distinguishesQualifiedFromUnqualifiedExports() throws Exception {
+        JavaModuleInfo m = JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()));
+
+        for (JavaModuleInfo.Directive d : m.exports()) {
+            if (d.packageName().equals("com.example.foo.api")) {
+                assertTrue(!d.isQualified(), "api export must be unqualified");
+            } else if (d.packageName().equals("com.example.foo.internal")) {
+                assertTrue(d.isQualified(), "internal export must be qualified");
+                assertEquals("com.example.bar", d.targets().get(0));
+            }
+        }
+    }
+
+    @Test
+    void returnsNullForPlainClassWithoutModuleAttribute() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "com/example/Plain", null, "java/lang/Object", null);
+        cw.visitEnd();
+        assertNull(JavaModuleInfoReader.read(new ByteArrayInputStream(cw.toByteArray())));
+    }
+
+    @Test
+    void readsTheOpenModuleFlag() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        ModuleVisitor mv = cw.visitModule("com.example.foo", Opcodes.ACC_OPEN, null);
+        mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        JavaModuleInfo open = JavaModuleInfoReader.read(new ByteArrayInputStream(cw.toByteArray()));
+        assertNotNull(open);
+        assertTrue(open.isOpen(), "expected an open module");
+
+        assertFalse(JavaModuleInfoReader.read(new ByteArrayInputStream(moduleInfo()))
+                .isOpen());
+    }
+
+    @Test
+    void failsClearlyForAClassFileNewerThanTheRuntime() {
+        byte[] classFile = moduleInfo();
+        // bump the class-file major version to one beyond this JVM so ModuleDescriptor.read cannot parse it
+        int runtimeMajor =
+                Integer.parseInt(System.getProperty("java.class.version").split("\\.")[0]);
+        int tooNew = runtimeMajor + 1;
+        classFile[6] = (byte) ((tooNew >> 8) & 0xFF);
+        classFile[7] = (byte) (tooNew & 0xFF);
+
+        IOException e =
+                assertThrows(IOException.class, () -> JavaModuleInfoReader.read(new ByteArrayInputStream(classFile)));
+        assertTrue(e.getMessage().contains("newer than the JVM"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -20,9 +20,16 @@ package org.apache.maven.enforcer.rules.modules;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.ModuleVisitor;
@@ -45,14 +52,53 @@ final class ModuleInfoFixtures {
         return new Builder(name, true);
     }
 
-    /** Write an arbitrary (empty) compiled class so an output directory looks non-empty to a rule. */
+    /**
+     * Write an arbitrary (empty) compiled class in its package directory so an output directory
+     * looks to a rule exactly like a compiler-produced one.
+     */
     static void writeDummyClass(File outputDirectory, String binaryName) throws IOException {
+        File classFile = new File(outputDirectory, binaryName.replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), dummyClass(binaryName));
+    }
+
+    private static byte[] dummyClass(String binaryName) {
         ClassWriter cw = new ClassWriter(0);
         cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
         cw.visitEnd();
-        File classFile = new File(outputDirectory, binaryName.replace('.', '/') + ".class");
-        Files.createDirectories(classFile.getParentFile().toPath());
-        Files.write(classFile.toPath(), cw.toByteArray());
+        return cw.toByteArray();
+    }
+
+    /**
+     * Write a dependency JAR fixture: dummy classes plus an optional {@code module-info.class}
+     * (explicit module) or an optional {@code Automatic-Module-Name} manifest entry.
+     *
+     * @param jarFile              the JAR file to create
+     * @param moduleInfo           bytes of a {@code module-info.class}, or {@code null}
+     * @param automaticModuleName  manifest {@code Automatic-Module-Name}, or {@code null}
+     * @param binaryClassNames     dot-separated names of dummy classes to include
+     */
+    static File writeJar(File jarFile, byte[] moduleInfo, String automaticModuleName, String... binaryClassNames)
+            throws IOException {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        if (automaticModuleName != null) {
+            manifest.getMainAttributes().putValue("Automatic-Module-Name", automaticModuleName);
+        }
+        try (OutputStream out = Files.newOutputStream(jarFile.toPath());
+                JarOutputStream jar = new JarOutputStream(out, manifest)) {
+            if (moduleInfo != null) {
+                jar.putNextEntry(new JarEntry("module-info.class"));
+                jar.write(moduleInfo);
+                jar.closeEntry();
+            }
+            for (String binaryName : binaryClassNames) {
+                jar.putNextEntry(new JarEntry(binaryName.replace('.', '/') + ".class"));
+                jar.write(dummyClass(binaryName));
+                jar.closeEntry();
+            }
+        }
+        return jarFile;
     }
 
     static final class Builder {
@@ -61,6 +107,7 @@ final class ModuleInfoFixtures {
         private final List<String> requires = new ArrayList<>();
         private final List<Directive> exports = new ArrayList<>();
         private final List<Directive> opens = new ArrayList<>();
+        private final Set<String> packages = new LinkedHashSet<>();
 
         private Builder(String name, boolean open) {
             this.name = name;
@@ -82,6 +129,14 @@ final class ModuleInfoFixtures {
             return this;
         }
 
+        /** Record packages in the {@code ModulePackages} attribute (exported/opened ones are added implicitly). */
+        Builder packages(String... packageNames) {
+            for (String packageName : packageNames) {
+                packages.add(packageName);
+            }
+            return this;
+        }
+
         byte[] toBytes() {
             ClassWriter cw = new ClassWriter(0);
             cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
@@ -95,6 +150,19 @@ final class ModuleInfoFixtures {
             }
             for (Directive open : opens) {
                 mv.visitOpen(open.internalName(), 0, open.targetsOrNull());
+            }
+            if (!packages.isEmpty()) {
+                // a ModulePackages attribute must be a superset of all exported/opened packages
+                Set<String> all = new LinkedHashSet<>(packages);
+                for (Directive export : exports) {
+                    all.add(export.packageName);
+                }
+                for (Directive open : opens) {
+                    all.add(open.packageName);
+                }
+                for (String packageName : all) {
+                    mv.visitPackage(packageName.replace('.', '/'));
+                }
             }
             mv.visitEnd();
             cw.visitEnd();

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Test-only helper that generates real {@code module-info.class} fixtures with ASM and writes them
+ * (plus optional dummy classes) into an output directory, so the module rules can be exercised against
+ * a {@code project.build.outputDirectory} exactly as they see it at build time.
+ */
+final class ModuleInfoFixtures {
+
+    private ModuleInfoFixtures() {}
+
+    static Builder module(String name) {
+        return new Builder(name, false);
+    }
+
+    static Builder openModule(String name) {
+        return new Builder(name, true);
+    }
+
+    /** Write an arbitrary (empty) compiled class so an output directory looks non-empty to a rule. */
+    static void writeDummyClass(File outputDirectory, String binaryName) throws IOException {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
+        cw.visitEnd();
+        Files.createDirectories(outputDirectory.toPath());
+        Files.write(new File(outputDirectory, binaryName + ".class").toPath(), cw.toByteArray());
+    }
+
+    static final class Builder {
+        private final String name;
+        private final boolean open;
+        private final List<String> requires = new ArrayList<>();
+        private final List<Directive> exports = new ArrayList<>();
+        private final List<Directive> opens = new ArrayList<>();
+
+        private Builder(String name, boolean open) {
+            this.name = name;
+            this.open = open;
+        }
+
+        Builder requires(String module) {
+            requires.add(module);
+            return this;
+        }
+
+        Builder exports(String packageName, String... targets) {
+            exports.add(new Directive(packageName, targets));
+            return this;
+        }
+
+        Builder opens(String packageName, String... targets) {
+            opens.add(new Directive(packageName, targets));
+            return this;
+        }
+
+        byte[] toBytes() {
+            ClassWriter cw = new ClassWriter(0);
+            cw.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+            ModuleVisitor mv = cw.visitModule(name, open ? Opcodes.ACC_OPEN : 0, null);
+            mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null);
+            for (String module : requires) {
+                mv.visitRequire(module, 0, null);
+            }
+            for (Directive export : exports) {
+                mv.visitExport(export.internalName(), 0, export.targetsOrNull());
+            }
+            for (Directive open : opens) {
+                mv.visitOpen(open.internalName(), 0, open.targetsOrNull());
+            }
+            mv.visitEnd();
+            cw.visitEnd();
+            return cw.toByteArray();
+        }
+
+        /** Write {@code module-info.class} into {@code outputDirectory} and return that directory. */
+        File writeTo(File outputDirectory) throws IOException {
+            Files.createDirectories(outputDirectory.toPath());
+            Files.write(new File(outputDirectory, "module-info.class").toPath(), toBytes());
+            return outputDirectory;
+        }
+    }
+
+    private static final class Directive {
+        private final String packageName;
+        private final String[] targets;
+
+        private Directive(String packageName, String[] targets) {
+            this.packageName = packageName;
+            this.targets = targets;
+        }
+
+        String internalName() {
+            return packageName.replace('.', '/');
+        }
+
+        /** ASM treats {@code null} (not an empty array) as an unqualified directive. */
+        String[] targetsOrNull() {
+            return targets.length == 0 ? null : targets;
+        }
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/ModuleInfoFixtures.java
@@ -50,8 +50,9 @@ final class ModuleInfoFixtures {
         ClassWriter cw = new ClassWriter(0);
         cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, binaryName.replace('.', '/'), null, "java/lang/Object", null);
         cw.visitEnd();
-        Files.createDirectories(outputDirectory.toPath());
-        Files.write(new File(outputDirectory, binaryName + ".class").toPath(), cw.toByteArray());
+        File classFile = new File(outputDirectory, binaryName.replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParentFile().toPath());
+        Files.write(classFile.toPath(), cw.toByteArray());
     }
 
     static final class Builder {

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModulesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireExplicitModulesTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class RequireExplicitModulesTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private RequireExplicitModules rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new RequireExplicitModules(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void aModularProjectWithClassesPasses() throws Exception {
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        ModuleInfoFixtures.module("com.example.foo").exports("com.example.foo").writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void compiledClassesWithoutModuleInfoFail() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("automatic module"), e.getMessage());
+    }
+
+    @Test
+    void aProjectWithNoCompiledClassesPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anOutputWithOnlyModuleInfoPasses() throws Exception {
+        // module-info.class but no other classes: nothing to encapsulate, so the rule stays silent.
+        ModuleInfoFixtures.module("com.example.foo").writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithExplicitModulesPasses() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        File api = new File(outputDirectory, "com.example.api");
+        ModuleInfoFixtures.writeDummyClass(api, "com.example.api.Service");
+        ModuleInfoFixtures.module("com.example.api").exports("com.example.api").writeTo(api);
+        File core = new File(outputDirectory, "com.example.core");
+        ModuleInfoFixtures.writeDummyClass(core, "com.example.core.Impl");
+        ModuleInfoFixtures.module("com.example.core")
+                .requires("com.example.api")
+                .writeTo(core);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithANonModularOutputFails() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        File api = new File(outputDirectory, "com.example.api");
+        ModuleInfoFixtures.writeDummyClass(api, "com.example.api.Service");
+        ModuleInfoFixtures.module("com.example.api").exports("com.example.api").writeTo(api);
+        // sibling output with classes but no module descriptor
+        File legacy = new File(outputDirectory, "com.example.legacy");
+        ModuleInfoFixtures.writeDummyClass(legacy, "com.example.legacy.Old");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.legacy"), e.getMessage());
+    }
+
+    @Test
+    void aCustomMessageIsUsed() throws Exception {
+        when(project.getArtifactId()).thenReturn("foo");
+        ModuleInfoFixtures.writeDummyClass(outputDirectory, "com.example.foo.Bar");
+        rule.setMessage("please add module-info.java");
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("please add module-info.java"), e.getMessage());
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExportsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/modules/RequireMinimalExportsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.modules;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.apache.maven.enforcer.rule.api.EnforcerLogger;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Reads module-info via java.lang.module.ModuleDescriptor, which exists only on Java 9+.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class RequireMinimalExportsTest {
+
+    @TempDir
+    File outputDirectory;
+
+    private final MavenProject project = mock(MavenProject.class);
+    private RequireMinimalExports rule;
+
+    @BeforeEach
+    void setUp() {
+        Build build = mock(Build.class);
+        when(build.getOutputDirectory()).thenReturn(outputDirectory.getAbsolutePath());
+        when(project.getBuild()).thenReturn(build);
+        rule = new RequireMinimalExports(project);
+        rule.setLog(mock(EnforcerLogger.class));
+    }
+
+    @Test
+    void exportingOnlyApiPackagesPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void exportingAnInternalPackageFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.api")
+                .exports("com.example.foo.internal")
+                .writeTo(outputDirectory);
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.foo.internal"), e.getMessage());
+    }
+
+    @Test
+    void qualifiedInternalExportIsIgnoredByDefault() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.example.bar")
+                .exports("com.example.foo.internal", "com.example.bar")
+                .writeTo(outputDirectory);
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void qualifiedInternalExportFailsWhenNotIgnored() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .requires("com.example.bar")
+                .exports("com.example.foo.internal", "com.example.bar")
+                .writeTo(outputDirectory);
+        rule.setIgnoreQualifiedExports(false);
+        assertThrows(EnforcerRuleException.class, rule::execute);
+    }
+
+    @Test
+    void whitelistedInternalExportPasses() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.internal")
+                .writeTo(outputDirectory);
+        rule.setAllowedExports(Arrays.asList("com.example.foo.internal"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void customPatternIsHonoured() throws Exception {
+        ModuleInfoFixtures.module("com.example.foo")
+                .exports("com.example.foo.secret")
+                .writeTo(outputDirectory);
+        rule.setInternalPackagePattern(".*\\.secret");
+        assertThrows(EnforcerRuleException.class, rule::execute);
+    }
+
+    @Test
+    void aNonModularProjectPasses() {
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void aModuleSourceHierarchyWithCleanExportsPasses() throws Exception {
+        // Maven 4 module source hierarchy: each module compiles to its own subdirectory.
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.core")
+                .exports("com.example.core.service")
+                .writeTo(new File(outputDirectory, "com.example.core"));
+        assertDoesNotThrow(rule::execute);
+    }
+
+    @Test
+    void anInternalExportInAModuleSourceHierarchyFails() throws Exception {
+        ModuleInfoFixtures.module("com.example.api")
+                .exports("com.example.api")
+                .writeTo(new File(outputDirectory, "com.example.api"));
+        ModuleInfoFixtures.module("com.example.core")
+                .exports("com.example.core.internal")
+                .writeTo(new File(outputDirectory, "com.example.core"));
+        EnforcerRuleException e = assertThrows(EnforcerRuleException.class, rule::execute);
+        assertTrue(e.getMessage().contains("com.example.core.internal"), e.getMessage());
+    }
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Re-declares com.acme.shared without even requiring the provider (silent split)</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>bsp-provider</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banSplitPackages/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-split-packages</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <!-- after compile: the rule intersects the compiled output with the dependencies -->
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/src/main/java/com/acme/shared/Copied.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/src/main/java/com/acme/shared/Copied.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** Accidentally placed into a foreign package. */
+public class Copied {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/consumer/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// the silent variant: the provider module is a declared dependency but NOT required
+module com.example.consumer {
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# compiles module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+# package: the provider JAR must exist before the consumer resolves it
+invoker.goals = package
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-split-packages-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>A dependency's package re-declared in the consumer module fails the build</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>provider</module>
+        <module>consumer</module>
+    </modules>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Explicit module owning the package com.acme.shared</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/src/main/java/com/acme/shared/Original.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/src/main/java/com/acme/shared/Original.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** The package owner's class. */
+public class Original {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/provider/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.acme.provider {
+    exports com.acme.shared;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-fail/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.BanSplitPackages failed with message')
+assert buildLog.text.contains('package com.acme.shared is contained in')
+assert buildLog.text.contains('com.example.consumer')
+assert buildLog.text.contains('com.acme.provider')

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
+    <modelVersion>4.1.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-msh-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Module com.example.app re-declares com.acme.shared without requiring the provider (silent split)</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>bsp-msh-provider</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Maven 4 module source hierarchy: each module compiles to target/classes/<module-name>/ -->
+        <sources>
+            <source>
+                <module>com.example.app</module>
+            </source>
+            <source>
+                <module>com.example.util</module>
+            </source>
+        </sources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>4.0.0-beta-3</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banSplitPackages/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-split-packages</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.app/main/java/com/acme/shared/Copied.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.app/main/java/com/acme/shared/Copied.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** Accidentally placed into a foreign package. */
+public class Copied {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.app/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.app/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// the silent variant: the provider module is a declared dependency but NOT required
+module com.example.app {
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.util/main/java/com/example/util/Helper.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.util/main/java/com/example/util/Helper.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.util;
+
+/** Lives in the module's own package. */
+public class Helper {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.util/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/consumer/src/com.example.util/main/java/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.util {
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/invoker.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# module source hierarchy (POM model 4.1.0) needs Maven 4; that in turn needs JDK 17+
+invoker.maven.version = 4.0.0-rc-5+
+invoker.java.version = 17+
+# package: the provider JAR must exist before the consumer resolves it
+invoker.goals = package
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-split-packages-msh-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>A module source hierarchy consumer re-declares a dependency's package</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>provider</module>
+        <module>consumer</module>
+    </modules>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-msh-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Explicit module owning the package com.acme.shared</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/src/main/java/com/acme/shared/Original.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/src/main/java/com/acme/shared/Original.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** The package owner's class. */
+public class Original {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/provider/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.acme.provider {
+    exports com.acme.shared;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-msh-fail/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.BanSplitPackages failed with message')
+assert buildLog.text.contains('package com.acme.shared is contained in')
+assert buildLog.text.contains('com.example.app')
+assert buildLog.text.contains('com.acme.provider')

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Keeps its classes in its own packages</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>bsp-provider</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banSplitPackages/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-split-packages</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <!-- after compile: the rule intersects the compiled output with the dependencies -->
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/src/main/java/com/example/consumer/App.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/src/main/java/com/example/consumer/App.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.consumer;
+
+/** Lives in the module's own package. */
+public class App {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/consumer/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.consumer {
+    requires com.acme.provider;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# compiles module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = package
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-split-packages-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>Disjoint packages between consumer and its dependency pass the rule</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>provider</module>
+        <module>consumer</module>
+    </modules>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Explicit module owning the package com.acme.shared</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/src/main/java/com/acme/shared/Original.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/src/main/java/com/acme/shared/Original.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** The package owner's class. */
+public class Original {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/provider/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.acme.provider {
+    exports com.acme.shared;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-pass/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert !buildLog.text.contains('failed with message')

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/consumer/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/consumer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-warn-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Non-modular consumer re-declaring com.acme.shared: legal today, warned as a migration hazard</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>test</groupId>
+            <artifactId>bsp-warn-provider</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banSplitPackages/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-split-packages</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <!-- after compile: the rule intersects the compiled output with the dependencies -->
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/consumer/src/main/java/com/acme/shared/Copied.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/consumer/src/main/java/com/acme/shared/Copied.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** Accidentally placed into a foreign package. */
+public class Copied {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 11+
+invoker.goals = package
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-split-packages-warn</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>A classpath-only package overlap is reported as a warning by default</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>provider</module>
+        <module>consumer</module>
+    </modules>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/provider/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/provider/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>bsp-warn-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>Non-modular JAR containing com.acme.shared</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/provider/src/main/java/com/acme/shared/Original.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/provider/src/main/java/com/acme/shared/Original.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.acme.shared;
+
+/** The package owner's class. */
+public class Original {}

--- a/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-split-packages-warn/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert buildLog.text.contains('package com.acme.shared is contained in')
+assert buildLog.text.contains('legal on the classpath')
+assert !buildLog.text.contains('failed with message')

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>ban-unjustified-opens-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>An unqualified opens fails banUnjustifiedOpens</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/dto/Dto.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/com/example/it/dto/Dto.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.dto;
+
+public class Dto {}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    opens com.example.it.dto;
+}

--- a/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/ban-unjustified-opens-fail/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.BanUnjustifiedOpens failed with message')
+assert buildLog.text.contains('opens package(s)')
+assert buildLog.text.contains('com.example.it.dto')

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+# process-classes compiles module-info.java before the enforcer execution runs
+invoker.goals = process-classes
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-info-rules-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>A well-encapsulated explicit module passes all three module rules</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                        <requireMinimalExports/>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <!-- after compile: the rules read the compiled module-info.class -->
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+/** Public API type — its package is the only unqualified export. */
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/dto/Dto.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/dto/Dto.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.dto;
+
+/** Reflected over by Jackson — its package is opened, but only to that named module. */
+public class Dto {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/internal/Helper.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/com/example/it/internal/Helper.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.internal;
+
+/** Internal detail — deliberately neither exported nor opened. */
+class Helper {}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    opens com.example.it.dto to com.fasterxml.jackson.databind;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-info-rules-pass/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert !buildLog.text.contains('failed with message')
+// sanity: the module descriptor really was compiled and thus available to the rules
+assert new File(basedir, 'target/classes/module-info.class').exists()

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# module source hierarchy (POM model 4.1.0) needs Maven 4; that in turn needs JDK 17+
+invoker.maven.version = 4.0.0-rc-5+
+invoker.java.version = 17+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+    root="true">
+    <modelVersion>4.1.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-source-hierarchy-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>One module in a Maven 4 module source hierarchy exports an internal package</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <!-- Maven 4 module source hierarchy: each module compiles to target/classes/<module-name>/ -->
+        <sources>
+            <source>
+                <module>com.example.api</module>
+            </source>
+            <source>
+                <module>com.example.core</module>
+            </source>
+        </sources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>4.0.0-beta-3</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireMinimalExports/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/com/example/api/Api.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/com/example/api/Api.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.api;
+
+public class Api {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.api/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.api {
+    exports com.example.api;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/com/example/core/internal/Impl.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/com/example/core/internal/Impl.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.core.internal;
+
+public class Impl {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/src/com.example.core/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.core {
+    requires com.example.api;
+    exports com.example.core.internal;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-fail/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireMinimalExports failed with message')
+assert buildLog.text.contains('exports internal package(s)')
+// the offending module in the hierarchy is named, the clean one is not flagged
+assert buildLog.text.contains('com.example.core.internal')

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# module source hierarchy (POM model 4.1.0) needs Maven 4; that in turn needs JDK 17+
+invoker.maven.version = 4.0.0-rc-5+
+invoker.java.version = 17+
+invoker.goals = process-classes
+invoker.buildResult = success

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd"
+    root="true">
+    <modelVersion>4.1.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>module-source-hierarchy-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Two well-encapsulated modules compiled from a Maven 4 module source hierarchy pass all rules</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <!-- Maven 4 module source hierarchy: each module compiles to target/classes/<module-name>/ -->
+        <sources>
+            <source>
+                <module>com.example.api</module>
+            </source>
+            <source>
+                <module>com.example.core</module>
+            </source>
+        </sources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>4.0.0-beta-3</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                        <requireMinimalExports/>
+                        <banUnjustifiedOpens/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/com/example/api/Api.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/com/example/api/Api.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.api;
+
+public class Api {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.api/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.api {
+    exports com.example.api;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/com/example/core/service/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/com/example/core/service/Service.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.core.service;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/src/com.example.core/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.example.core {
+    requires com.example.api;
+    exports com.example.core.service;
+}

--- a/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/module-source-hierarchy-pass/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('BUILD SUCCESS')
+assert !buildLog.text.contains('failed with message')
+// the module source hierarchy really produced one output per module
+assert new File(basedir, 'target/classes/com.example.api/module-info.class').exists()
+assert new File(basedir, 'target/classes/com.example.core/module-info.class').exists()

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>require-explicit-modules-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>A project with classes but no module-info.class is not an explicit module</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireExplicitModules/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/src/main/java/com/example/it/App.java
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/src/main/java/com/example/it/App.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it;
+
+/** Compiled class with no module-info.java — the artifact would be an automatic module. */
+public class App {}

--- a/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-explicit-modules-fail/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireExplicitModules failed with message')
+assert buildLog.text.contains('is not an explicit Java module')

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/invoker.properties
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# these ITs compile a module-info.java (release 11); skip on JDK < 11
+invoker.java.version = 11+
+invoker.goals = process-classes
+invoker.buildResult = failure

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>require-minimal-exports-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <description>Exporting an internal package fails requireMinimalExports</description>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <rules>
+                        <requireMinimalExports/>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-module-info</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/api/Service.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/api/Service.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.api;
+
+public class Service {}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/internal/Impl.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/com/example/it/internal/Impl.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.example.it.internal;
+
+/** Internal detail that must not be part of the module's public surface. */
+public class Impl {}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/module-info.java
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.example.it {
+    exports com.example.it.api;
+    exports com.example.it.internal;
+}

--- a/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/require-minimal-exports-fail/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.text.contains('org.apache.maven.enforcer.rules.modules.RequireMinimalExports failed with message')
+assert buildLog.text.contains('exports internal package(s)')
+assert buildLog.text.contains('com.example.it.internal')


### PR DESCRIPTION
Implements the `banSplitPackages` rule proposed in #997 — the follow-up announced in #996.

> [!IMPORTANT]
> **Stacked on #996.** The first four commits are #996 (module-info reader + three rules); only the top three commits (`feat` / `test` / `docs` for `banSplitPackages`) are new here. Once #996 merges I will rebase onto master and the diff collapses to just the new rule. Draft until then.

## Rule

A package must belong to exactly one Java module — two modules on the module path containing the same package fail resolution (`java.lang.module.ResolutionException`), typically at packaging, `jlink`, or first boot, with a symptom-not-cause message. And if the offending module is not even `requires`d, the resolver never pulls it in: the build stays green while a type or endpoint is silently absent at runtime.

- **Project packages** come from **walking the output directory**, not the compiled descriptor — `ModulePackages` is only finalized at packaging time, and offending classes are frequently added *after* compile (code generation, copied resources). Both the classic layout and the **Maven 4 module source hierarchy** are supported (same `moduleOutputs()` discovery as #996).
- **Dependency packages** are read through `java.lang.module.ModuleFinder` (reflectively — same Java 8 baseline rationale as the reader in #996), which derives automatic-module names and reports complete package sets; artifacts the finder cannot model fall back to a plain class-file scan.
- The rule intersects against the **full declared-dependency set**, deliberately not only the `requires`d modules — this is what catches the silent variant.
- **Severity model:** overlap between two artifacts that both end up on the module path → **error**. An automatic module counts as "on the module path" only when a project module actually `requires` its derived name. Overlaps involving a classpath-only artifact are legal today and reported at `<classpathSeverity>` (default `warn`) as a modularization hazard.
- **Configuration:** `classpathSeverity` (`warn`/`error`/`ignore`), `allowedSplitPackages`, `ignoredModules`, `ignoredArtifacts`, `message`.
- **Non-goal:** a provider that is not a declared Maven dependency (pure runtime) is out of scope. The rule is a safety net, not a fix — the durable cure is placing generated/copied classes in the module that owns their package.

## Design note: dependency resolution

`ResolverUtil` is widened to `public`: the `enforce` mojo declares only `requiresDependencyCollection`, so artifact *files* are not resolved by default; the rule resolves them explicitly — the same approach `enforceBytecodeVersion` already uses.

## Tests

- 15 unit tests (Java 9+ gated; ASM fixtures in test scope only, extended with a JAR fixture writer for explicit/automatic/plain dependency artifacts).
- Four ITs under `maven-enforcer-plugin/src/it/projects/`: a classic two-artifact reactor failing on the silent variant, a clean pass, a classpath-overlap warn case (build succeeds, warning names the automatic module), and a Maven 4 module-source-hierarchy fail case (gated `4.0.0-rc-5+` / JDK 17+).
- Full `mvn clean verify -P run-its` green on Maven 3.10.0-rc-1 (158 ITs passed); the four new ITs additionally verified on Maven 4.0.0-rc-5.

---
- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

(Replaces #999, which GitHub auto-closed when the head branch was renamed to `feature/997-ban-split-packages`.)
