### PR TITLE
fix: support groupId-only includes in RequireUpperBoundDeps rule (#998)

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
@@ -203,7 +204,7 @@ public final class RequireUpperBoundDeps extends AbstractStandardEnforcerRule {
 
         private final ParentsVisitor parentsVisitor = new ParentsVisitor();
         private boolean uniqueVersions;
-        private List<String> includes = null;
+        private Predicate<Artifact> includesMatcher = null;
 
         public RequireUpperBoundDepsVisitor setUniqueVersions(boolean uniqueVersions) {
             this.uniqueVersions = uniqueVersions;
@@ -211,7 +212,9 @@ public final class RequireUpperBoundDeps extends AbstractStandardEnforcerRule {
         }
 
         public RequireUpperBoundDepsVisitor setIncludes(List<String> includes) {
-            this.includes = includes;
+            this.includesMatcher = includes != null && !includes.isEmpty()
+                    ? ArtifactUtils.prepareDependencyArtifactMatcher(includes)
+                    : null;
             return this;
         }
 
@@ -223,8 +226,11 @@ public final class RequireUpperBoundDeps extends AbstractStandardEnforcerRule {
             DependencyNodeHopCountPair pair = new DependencyNodeHopCountPair(node, this);
             String key = pair.constructKey();
 
-            if (includes != null && !includes.isEmpty() && !includes.contains(key)) {
-                return true;
+            if (includesMatcher != null) {
+                Artifact artifact = ArtifactUtils.toArtifact(node);
+                if (!includesMatcher.test(artifact)) {
+                    return true;
+                }
             }
 
             keyToPairsMap.computeIfAbsent(key, k1 -> new ArrayList<>()).add(pair);

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDepsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDepsTest.java
@@ -27,6 +27,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -63,5 +65,56 @@ class RequireUpperBoundDepsTest {
                 .isInstanceOf(EnforcerRuleException.class)
                 .hasMessageContaining("default-group:childA:1.0.0:classifier")
                 .hasMessageContaining("default-group:childA:2.0.0:classifier");
+    }
+
+    @Test
+    void testIncludesWithGroupIdOnly() throws Exception {
+
+        rule.setLog(mock(EnforcerLogger.class));
+        rule.setIncludes(Collections.singletonList("default-group"));
+
+        when(resolverUtil.resolveTransitiveDependenciesVerbose(anyList()))
+                .thenReturn(new DependencyNodeBuilder()
+                        .withType(DependencyNodeBuilder.Type.POM)
+                        .withChildNode(new DependencyNodeBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("childA")
+                                .withVersion("1.0.0")
+                                .build())
+                        .withChildNode(new DependencyNodeBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("childA")
+                                .withVersion("2.0.0")
+                                .build())
+                        .build());
+
+        assertThatCode(rule::execute)
+                .isInstanceOf(EnforcerRuleException.class)
+                .hasMessageContaining("default-group:childA:1.0.0:classifier");
+    }
+
+    @Test
+    void testIncludesWithGroupIdOnlyExcludesOtherGroup() throws Exception {
+
+        rule.setLog(mock(EnforcerLogger.class));
+        rule.setIncludes(Collections.singletonList("other-group"));
+
+        when(resolverUtil.resolveTransitiveDependenciesVerbose(anyList()))
+                .thenReturn(new DependencyNodeBuilder()
+                        .withType(DependencyNodeBuilder.Type.POM)
+                        .withChildNode(new DependencyNodeBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("childA")
+                                .withVersion("1.0.0")
+                                .build())
+                        .withChildNode(new DependencyNodeBuilder()
+                                .withGroupId("default-group")
+                                .withArtifactId("childA")
+                                .withVersion("2.0.0")
+                                .build())
+                        .build());
+
+        assertThatCode(rule::execute)
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
### Summary

Fixes #998.

The `RequireUpperBoundDeps` rule documentation states that the `includes` parameter accepts `groupId[:artifactId]` format (with `artifactId` being optional), but the implementation only supported exact string matching via `List.contains()`. This meant specifying just a `groupId` (e.g., `com.example`) would not match dependencies like `com.example:my-lib`.

### Changes

- Changed `RequireUpperBoundDepsVisitor.includes` from `List<String>` to `Predicate<Artifact> includesMatcher`
- Used `ArtifactUtils.prepareDependencyArtifactMatcher()` to create the predicate — the same approach used by `BannedDependencies`, `RequireReleaseDeps`, and other rules that already support `groupId[:artifactId]` format
- Updated `visitEnter()` to use the predicate instead of direct string comparison

### Tests

- Added `testIncludesWithGroupIdOnly()` — verifies that `includes = ["default-group"]` correctly detects conflicts for dependencies with that groupId
- Added `testIncludesWithGroupIdOnlyExcludesOtherGroup()` — verifies that `includes = ["other-group"]` correctly ignores dependencies with a different groupId
- All 3 tests pass (1 existing + 2 new)