### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/enforcer-api/src/site/markdown/index.md
+++ b/enforcer-api/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-api/src/site/markdown/writing-a-custom-rule.md
+++ b/enforcer-api/src/site/markdown/writing-a-custom-rule.md
@@ -1,3 +1,10 @@
+---
+title: Writing a custom rule
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/alwaysFail.md.vm
+++ b/enforcer-rules/src/site/markdown/alwaysFail.md.vm
@@ -1,3 +1,10 @@
+---
+title: Always Fail
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/alwaysPass.md.vm
+++ b/enforcer-rules/src/site/markdown/alwaysPass.md.vm
@@ -1,3 +1,10 @@
+---
+title: Always Pass
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/banDependencyManagementScope.md.vm
+++ b/enforcer-rules/src/site/markdown/banDependencyManagementScope.md.vm
@@ -1,3 +1,10 @@
+---
+title: Ban Dependency Management Scope
+author: 
+  - Konrad Windszus
+date: 2022-06-28
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/banDistributionManagement.md.vm
+++ b/enforcer-rules/src/site/markdown/banDistributionManagement.md.vm
@@ -1,3 +1,10 @@
+---
+title: Ban Distribution Management
+author: 
+  - Karl-Heinz Marbaise
+date: 2014-06-28
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/banDuplicatePomDependencyVersions.md.vm
+++ b/enforcer-rules/src/site/markdown/banDuplicatePomDependencyVersions.md.vm
@@ -1,3 +1,10 @@
+---
+title: Ban Duplicate Pom Dependency Versions
+author: 
+  - Guillaume Boue
+date: 2016-11-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/banDynamicVersions.md.vm
+++ b/enforcer-rules/src/site/markdown/banDynamicVersions.md.vm
@@ -1,3 +1,10 @@
+---
+title: Ban Dynamic Versions
+author: 
+  - Konrad Windszus
+date: 2022-10-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/banTransitiveDependencies.md.vm
+++ b/enforcer-rules/src/site/markdown/banTransitiveDependencies.md.vm
@@ -1,3 +1,8 @@
+---
+title: Ban Transitive Dependencies
+date: 2012-10-09
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/bannedDependencies.md.vm
+++ b/enforcer-rules/src/site/markdown/bannedDependencies.md.vm
@@ -1,3 +1,10 @@
+---
+title: Banned Dependencies
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/bannedPlugins.md.vm
+++ b/enforcer-rules/src/site/markdown/bannedPlugins.md.vm
@@ -1,3 +1,10 @@
+---
+title: Banned Plugins
+author: 
+  - Paul Gier
+date: 2012-11-23
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/bannedRepositories.md.vm
+++ b/enforcer-rules/src/site/markdown/bannedRepositories.md.vm
@@ -1,3 +1,10 @@
+---
+title: Banned Specified Repositories
+author: 
+  - Simon Wang
+date: 2014-06-15
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/dependencyConvergence.md.vm
+++ b/enforcer-rules/src/site/markdown/dependencyConvergence.md.vm
@@ -1,3 +1,8 @@
+---
+title: Dependency Convergence
+date: 2008-09-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/enforceBytecodeVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/enforceBytecodeVersion.md.vm
@@ -1,3 +1,10 @@
+---
+title: Enforce Bytecode Version
+author: 
+  - Baptiste Mathus
+date: Mars 2013
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/evaluateBeanshell.md.vm
+++ b/enforcer-rules/src/site/markdown/evaluateBeanshell.md.vm
@@ -1,3 +1,10 @@
+---
+title: Beanshell
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/externalRules.md.vm
+++ b/enforcer-rules/src/site/markdown/externalRules.md.vm
@@ -1,3 +1,10 @@
+---
+title: External Rules
+author: 
+  - George Gastaldi
+date: 2022-08-17
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/index.md
+++ b/enforcer-rules/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Built-In Rules
+author: 
+  - Brian Fox
+date: 2015-01-27
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/reactorModuleConvergence.md.vm
+++ b/enforcer-rules/src/site/markdown/reactorModuleConvergence.md.vm
@@ -1,3 +1,10 @@
+---
+title: Reactor Module Convergence
+author: 
+  - Karl-Heinz Marbaise
+date: 2014-03-14
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireActiveProfile.md.vm
+++ b/enforcer-rules/src/site/markdown/requireActiveProfile.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Active Profile
+author: 
+  - Karl-Heinz Marbaise
+date: 2014-01-09
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireEnvironmentVariable.md.vm
+++ b/enforcer-rules/src/site/markdown/requireEnvironmentVariable.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Environment Variable
+author: 
+  - Karl-Heinz Marbaise
+date: 2014-01-07
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireExplicitDependencyScope.md.vm
+++ b/enforcer-rules/src/site/markdown/requireExplicitDependencyScope.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Explicit Dependency Scope
+author: 
+  - Konrad Windszus
+date: 2022-08-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireFileChecksum.md.vm
+++ b/enforcer-rules/src/site/markdown/requireFileChecksum.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Files Checksum
+author: 
+  - Edward Samson, Lyubomyr Shaydariv
+date: 2016-11-26
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireFilesDontExist.md.vm
+++ b/enforcer-rules/src/site/markdown/requireFilesDontExist.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Files Don't Exist
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireFilesExist.md.vm
+++ b/enforcer-rules/src/site/markdown/requireFilesExist.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Files Exist
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireFilesSize.md.vm
+++ b/enforcer-rules/src/site/markdown/requireFilesSize.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require File Size
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireJavaVendor.md.vm
+++ b/enforcer-rules/src/site/markdown/requireJavaVendor.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Java Vendor
+author: 
+  - Tim Sijstermans
+date: 2020-07-31
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireJavaVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/requireJavaVersion.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Java Version
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireMatchingCoordinates.md.vm
+++ b/enforcer-rules/src/site/markdown/requireMatchingCoordinates.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Matching Coordinates
+author: 
+  - Konrad Windszus
+date: 2024-03-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireMavenVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/requireMavenVersion.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Maven Version
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireNoRepositories.md.vm
+++ b/enforcer-rules/src/site/markdown/requireNoRepositories.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require No Repositories
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireOS.md.vm
+++ b/enforcer-rules/src/site/markdown/requireOS.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require OS Version
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requirePluginVersions.md.vm
+++ b/enforcer-rules/src/site/markdown/requirePluginVersions.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Plugin Versions
+author: 
+  - Brian Fox
+date: 2009-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requirePrerequisite.md.vm
+++ b/enforcer-rules/src/site/markdown/requirePrerequisite.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Same Version
+author: 
+  - Robert Scholte
+date: 2013-06-16
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireProfileIdsExist.md.vm
+++ b/enforcer-rules/src/site/markdown/requireProfileIdsExist.md.vm
@@ -1,3 +1,8 @@
+---
+title: Require Existence of Profiles Specified on the Commandline
+date: 2017-09-25
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireProperty.md.vm
+++ b/enforcer-rules/src/site/markdown/requireProperty.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Property
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireReleaseDeps.md.vm
+++ b/enforcer-rules/src/site/markdown/requireReleaseDeps.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Release Dependencies
+author: 
+  - Brian Fox
+date: 2008-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireReleaseVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/requireReleaseVersion.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Release Version
+author: 
+  - Brian Fox
+date: 2008-08-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireSameVersions.md.vm
+++ b/enforcer-rules/src/site/markdown/requireSameVersions.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Same Version
+author: 
+  - Robert Scholte
+date: 2013-06-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireSnapshotVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/requireSnapshotVersion.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Snapshot Version
+author: 
+  - Guillaume Boue
+date: 2016-09-20
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireTextFileChecksum.md.vm
+++ b/enforcer-rules/src/site/markdown/requireTextFileChecksum.md.vm
@@ -1,3 +1,10 @@
+---
+title: Require Text Files Checksum
+author: 
+  - Konrad Windszus
+date: 2020-09-13
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/requireUpperBoundDeps.md.vm
+++ b/enforcer-rules/src/site/markdown/requireUpperBoundDeps.md.vm
@@ -1,3 +1,8 @@
+---
+title: Require Upper Bound Dependencies
+date: 2012-02-08
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/enforcer-rules/src/site/markdown/versionRanges.md
+++ b/enforcer-rules/src/site/markdown/versionRanges.md
@@ -1,3 +1,10 @@
+---
+title: Version Range Specification
+author: 
+  - Brian Fox
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-enforcer-extension/src/site/markdown/index.md
+++ b/maven-enforcer-extension/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Robert Scholte
+date: 2021-05-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-enforcer-plugin/src/site/markdown/examples/check-specific-rule-via-cli.md.vm
+++ b/maven-enforcer-plugin/src/site/markdown/examples/check-specific-rule-via-cli.md.vm
@@ -1,3 +1,10 @@
+---
+title: Check specific rule via CLI
+author: 
+  - Sandra Parsick
+date: 2018-06-19
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-enforcer-plugin/src/site/markdown/index.md
+++ b/maven-enforcer-plugin/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Brian Fox
+date: 2007-03-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-enforcer-plugin/src/site/markdown/thirdparty-rules.md
+++ b/maven-enforcer-plugin/src/site/markdown/thirdparty-rules.md
@@ -1,3 +1,10 @@
+---
+title: Thirdparty Rules
+author: 
+  - Jason Dillon
+date: 2018-08-27
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-enforcer-plugin/src/site/markdown/usage.md.vm
+++ b/maven-enforcer-plugin/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Brian Fox
+date: 2007-03-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.