### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/enforcer-rules/src/site/markdown/requireJavaVersion.md.vm
+++ b/enforcer-rules/src/site/markdown/requireJavaVersion.md.vm
@@ -31,9 +31,9 @@ The following parameters are supported by this rule:
 
 The JDK version is retrieved and the following processing occurs before being checked:
 
-1. Drop all non-numeric characters preceding the first number. (build 1.5.0\_07-b03 becomes 1.5.0\_07-b03)
-1. Replace all '\_' and '-' with '.' (1.5.0\_07-b03 becomes 1.5.0.07.b03)
-1. Remove all non digit characters "\[^0-9\] and convert each section using Integer.parseInt() (1.5.0\_07-b03 becomes 1.5.0.7.3)
+1. Drop all non-numeric characters preceding the first number. (build 1.5.0_07-b03 becomes 1.5.0_07-b03)
+1. Replace all '\_' and '-' with '.' (1.5.0_07-b03 becomes 1.5.0.07.b03)
+1. Remove all non digit characters "\[^0-9\] and convert each section using Integer.parseInt() (1.5.0_07-b03 becomes 1.5.0.7.3)
 1. Split the string on '.' and take the first 3 sections, separated by '.' and add '-' followed by the fourth section (1.5.0.7.3 becomes 1.5.0-7)
 
 This preprocessing normalizes various JDK version strings into a standard x.y.z-b version number. Your required range should therefore use the x.y.z-b format for comparison. There is an easy way to see how your current JDK string will be normalized, you can enable **display** option.

--- a/enforcer-rules/src/site/markdown/versionRanges.md
+++ b/enforcer-rules/src/site/markdown/versionRanges.md
@@ -32,4 +32,4 @@ The [RequireMavenVersion](./requireMavenVersion.html) and [RequireJavaVersion](.
 |(1.0,2.0)|1.0 &lt; x &lt; 2.0|
 |\[1.0,2.0\]|1.0 &lt;= x &lt;= 2.0|
 |(,1.0\],\[1.2,)|x &lt;= 1.0 or x &gt;= 1.2. Multiple sets are comma-separated|
-|(,1.1),(1.1,)|x \!= 1.1|
+|(,1.1),(1.1,)|x != 1.1|


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.