### PR TITLE
Use <a id> rather than <a name> for the FAQ anchors

### DIFF
--- a/maven-enforcer-plugin/src/site/markdown/faq.md
+++ b/maven-enforcer-plugin/src/site/markdown/faq.md
@@ -21,13 +21,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<a name="top"></a>
+<a id="top"></a>
 
 # Frequently Asked Questions
 
 1. [Why can't I just use the prerequisites tag in the pom?](#question)
 
-<a name="question"></a>
+<a id="question"></a>
 
 ### Why can't I just use the prerequisites tag in the pom?
 


### PR DESCRIPTION
Follow-up to #1009. That PR converted the FAQ from FML to Markdown and landed with
the anchors written as `<a name>`; this switches them to `<a id>`.

### Why this matters

**maven-site-plugin 3.21.0 strips the `name=` attribute from inline HTML anchors;
3.22.0 keeps it.** A page written with `<a name>` therefore loses its anchors on the
older plugin — with a green build, `mvn site` exiting 0, and no warning. That was
demonstrated elsewhere in the estate on a project still inheriting the older parent,
where all four anchors vanished silently.

`<a id>` works on both. Doxia's `Xhtml5BaseParser` reads `Attribute.ID` first and only
falls back to `NAME`, so `id` is the primary path — and `name` on `<a>` is obsolete in
HTML5 regardless.

This project inherits `maven-plugins:49`, which pulls 3.22.0, so **the published
anchors are not currently affected**. This is a correctness and consistency fix rather
than a live breakage: it makes the page right on both versions, keeps it right if the
FAQ is ever back-ported to a maintenance line with an older toolchain, and aligns this
file with the rest of the estate-wide FML-to-Markdown conversion, which uses `<a id>`
throughout.

### Verification

Site generated before and after; the set of anchors the generated `faq.html` actually
serves is unchanged:

```
question
top
```

plus the ids Doxia derives from the headings. The `<head>` is byte-identical, and the
build emits no duplicate-anchor warning.

Both anchors are load-bearing here and are kept: the FML id was the slug `question`,
which the question text does not reproduce, so neither is redundant with a
heading-derived id.

Generated-by: Claude Opus 5 (1M context)