### PR TITLE
RequireFilesExist should accept a file reached through .. (#977)

### DIFF
--- a/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/files/RequireFilesExist.java
+++ b/enforcer-rules/src/main/java/org/apache/maven/enforcer/rules/files/RequireFilesExist.java
@@ -22,6 +22,7 @@ import javax.inject.Named;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * The Class RequireFilesExist.
@@ -54,7 +55,15 @@ public final class RequireFilesExist extends AbstractRequireFiles {
                 absFile = file;
             }
 
-            return absFile.toURI().equals(absFile.getCanonicalFile().toURI());
+            // Collapse ".." first. A path that still contains those segments never
+            // has the same URI as getCanonicalFile(), so an existing file is
+            // reported missing. Compare the file name rather than the full URI
+            // so /var vs /private/var on macOS does not fail the same way.
+            Path requested = absFile.toPath().toAbsolutePath().normalize();
+            return requested
+                    .getFileName()
+                    .toString()
+                    .equals(requested.toFile().getCanonicalFile().getName());
         } catch (IOException e) {
             return true;
         }

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesExist.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesExist.java
@@ -20,6 +20,7 @@ package org.apache.maven.enforcer.rules.files;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -106,6 +107,20 @@ class TestRequireFilesExist {
         EnforcerRuleException e = assertThrows(EnforcerRuleException.class, () -> rule.execute());
 
         assertNotNull(e.getMessage());
+    }
+
+    @Test
+    void testFileExistsThroughDotDot() throws Exception {
+        File nested = new File(temporaryFolder, "src/a/b");
+        assertTrue(nested.mkdirs());
+        File readme = new File(temporaryFolder, "README.adoc");
+        Files.write(readme.toPath(), "ok".getBytes());
+
+        File viaDotDot = new File(nested, "../../../README.adoc");
+        assertTrue(viaDotDot.exists());
+
+        rule.setFilesList(Collections.singletonList(viaDotDot));
+        rule.execute();
     }
 
     @Test


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

RequireFilesExist compared the configured path's URI to getCanonicalFile(). A path with `..` never matches, so a file that exists is reported missing. I hit this on macOS with `${project.basedir}/../../../README.adoc`.

I collapse `..` first and then compare the file names. That keeps the Windows case check and also survives `/var` vs `/private/var` on macOS temp dirs.

`TestRequireFilesExist.testFileExistsThroughDotDot` fails on the old URI compare.

Fixes #977
