### PR TITLE
Stop dependabot from updating test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ version: 2
 updates:
 - package-ecosystem: maven
   directory: "/"
+  exclude-paths:
+    - "enforcer-api/src/custom-rule-sample/**"
+    - "enforcer-rules/src/test/resources/**"
+    - "maven-enforcer-extension/src/it/**"
+    - "maven-enforcer-plugin/src/it/**"
   schedule:
     interval: daily
 


### PR DESCRIPTION
Dependabot bumps fixture poms whose pinned version is the test input; #1012 fails on the exact IT it touches. Same fix as mojohaus/license-maven-plugin@c43d4ee0, after which that repo's stream of `src/it` PRs stopped. The trees without a past PR hold fixture poms too, and are excluded pre-emptively.

Supersedes #1012.

*This change was created with AI assistance.*