### PR TITLE
Build artifact stubs locally instead of via the testing harness

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -113,17 +113,6 @@
       <version>2.0b6</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!-- used in test runtime for ArtifactStubFactory -->
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>3.0</version>

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireReleaseVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireReleaseVersion.java
@@ -19,7 +19,7 @@
 package org.apache.maven.enforcer.rules;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +49,7 @@ class TestRequireReleaseVersion {
 
     @Test
     void testProjectWithReleaseVersion() throws Exception {
-        ArtifactStubFactory factory = new ArtifactStubFactory();
+        EnforcerArtifactStubFactory factory = new EnforcerArtifactStubFactory();
 
         when(project.getArtifact()).thenReturn(factory.getReleaseArtifact());
 
@@ -58,7 +58,7 @@ class TestRequireReleaseVersion {
 
     @Test
     void testProjectWithSnapshotVersion() throws Exception {
-        ArtifactStubFactory factory = new ArtifactStubFactory();
+        EnforcerArtifactStubFactory factory = new EnforcerArtifactStubFactory();
 
         when(project.getArtifact()).thenReturn(factory.getSnapshotArtifact());
 
@@ -69,7 +69,7 @@ class TestRequireReleaseVersion {
 
     @Test
     void shouldFailWhenParentIsSnapshot() throws Exception {
-        ArtifactStubFactory factory = new ArtifactStubFactory();
+        EnforcerArtifactStubFactory factory = new EnforcerArtifactStubFactory();
 
         when(project.getArtifact()).thenReturn(factory.getReleaseArtifact());
         when(project.getParentArtifact()).thenReturn(factory.getSnapshotArtifact());
@@ -83,7 +83,7 @@ class TestRequireReleaseVersion {
 
     @Test
     void shouldAllowParentSnapshot() throws Exception {
-        ArtifactStubFactory factory = new ArtifactStubFactory();
+        EnforcerArtifactStubFactory factory = new EnforcerArtifactStubFactory();
 
         when(project.getArtifact()).thenReturn(factory.getReleaseArtifact());
 

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireReleaseVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireReleaseVersion.java
@@ -19,7 +19,7 @@
 package org.apache.maven.enforcer.rules;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  */
 class TestRequireSameVersions {
-    private static final ArtifactStubFactory ARTIFACT_FACTORY = new ArtifactStubFactory();
+    private static final EnforcerArtifactStubFactory ARTIFACT_FACTORY = new EnforcerArtifactStubFactory();
 
     private MavenProject project;
     private RequireSameVersions rule;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSameVersions.java
@@ -23,8 +23,8 @@ import java.util.HashSet;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSnapshotVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSnapshotVersion.java
@@ -19,7 +19,7 @@
 package org.apache.maven.enforcer.rules;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSnapshotVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/TestRequireSnapshotVersion.java
@@ -19,7 +19,7 @@
 package org.apache.maven.enforcer.rules;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,14 +43,14 @@ class TestRequireSnapshotVersion {
     @Mock
     private MavenProject project;
 
-    private ArtifactStubFactory factory;
+    private EnforcerArtifactStubFactory factory;
 
     @InjectMocks
     private RequireSnapshotVersion rule;
 
     @BeforeEach
     public void before() {
-        factory = new ArtifactStubFactory();
+        factory = new EnforcerArtifactStubFactory();
     }
 
     @Test

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
@@ -21,9 +21,9 @@ package org.apache.maven.enforcer.rules.dependency;
 import java.util.Collections;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.enforcer.rules.utils.DependencyNodeBuilder;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/BannedDependenciesTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.enforcer.rules.dependency;
 import java.util.Collections;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.enforcer.rules.utils.DependencyNodeBuilder;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class BannedDependenciesTest {
 
-    private static final ArtifactStubFactory ARTIFACT_STUB_FACTORY = new ArtifactStubFactory();
+    private static final EnforcerArtifactStubFactory ARTIFACT_STUB_FACTORY = new EnforcerArtifactStubFactory();
 
     @Mock
     private MavenProject project;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireReleaseDepsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireReleaseDepsTest.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Collections;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.enforcer.rules.utils.DependencyNodeBuilder;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 class RequireReleaseDepsTest {
-    private static final ArtifactStubFactory ARTIFACT_STUB_FACTORY = new ArtifactStubFactory();
+    private static final EnforcerArtifactStubFactory ARTIFACT_STUB_FACTORY = new EnforcerArtifactStubFactory();
 
     @Mock
     private MavenProject project;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireReleaseDepsTest.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/dependency/RequireReleaseDepsTest.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.util.Collections;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.enforcer.rules.utils.DependencyNodeBuilder;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesSize.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesSize.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.EnforcerArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +108,7 @@ class TestRequireFilesSize {
 
         File f = File.createTempFile("junit", null, temporaryFolder);
 
-        ArtifactStubFactory factory = new ArtifactStubFactory();
+        EnforcerArtifactStubFactory factory = new EnforcerArtifactStubFactory();
         Artifact a = factory.getReleaseArtifact();
         a.setFile(f);
 

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesSize.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/files/TestRequireFilesSize.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.plugin.testing.ArtifactStubFactory;
+import org.apache.maven.enforcer.rules.utils.ArtifactStubFactory;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/ArtifactStubFactory.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/ArtifactStubFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.enforcer.rules.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+
+/**
+ * Builds detached {@link Artifact} stubs for rule tests. No file is created and none is attached; a test that
+ * needs one calls {@link Artifact#setFile}.
+ */
+public class ArtifactStubFactory {
+
+    /**
+     * @return {@code testGroupId:release:jar:1.0}, compile scope
+     */
+    public Artifact getReleaseArtifact() {
+        return createArtifact("testGroupId", "release", "1.0");
+    }
+
+    /**
+     * @return {@code testGroupId:snapshot:jar:2.0-SNAPSHOT}, compile scope
+     */
+    public Artifact getSnapshotArtifact() {
+        return createArtifact("testGroupId", "snapshot", "2.0-SNAPSHOT");
+    }
+
+    /**
+     * @return one jar per scope: {@code g:compile}, {@code g:provided}, {@code g:test}, {@code g:runtime},
+     *         {@code g:system}, all at 1.0
+     */
+    public Set<Artifact> getScopedArtifacts() {
+        Set<Artifact> set = new HashSet<>();
+        set.add(createArtifact("g", "compile", "1.0", Artifact.SCOPE_COMPILE, "jar", ""));
+        set.add(createArtifact("g", "provided", "1.0", Artifact.SCOPE_PROVIDED, "jar", ""));
+        set.add(createArtifact("g", "test", "1.0", Artifact.SCOPE_TEST, "jar", ""));
+        set.add(createArtifact("g", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", ""));
+        set.add(createArtifact("g", "system", "1.0", Artifact.SCOPE_SYSTEM, "jar", ""));
+        return set;
+    }
+
+    /**
+     * @return one compile-scoped artifact per type: {@code g:a:war}, {@code g:b:jar}, {@code g:c:sources},
+     *         {@code g:d:zip}, {@code g:e:rar}, all at 1.0
+     */
+    public Set<Artifact> getTypedArtifacts() {
+        Set<Artifact> set = new HashSet<>();
+        set.add(createArtifact("g", "a", "1.0", Artifact.SCOPE_COMPILE, "war", null));
+        set.add(createArtifact("g", "b", "1.0", Artifact.SCOPE_COMPILE, "jar", null));
+        set.add(createArtifact("g", "c", "1.0", Artifact.SCOPE_COMPILE, "sources", null));
+        set.add(createArtifact("g", "d", "1.0", Artifact.SCOPE_COMPILE, "zip", null));
+        set.add(createArtifact("g", "e", "1.0", Artifact.SCOPE_COMPILE, "rar", null));
+        return set;
+    }
+
+    /**
+     * @return a compile-scoped jar for the given coordinates
+     */
+    public Artifact createArtifact(String groupId, String artifactId, String version) {
+        return createArtifact(groupId, artifactId, version, Artifact.SCOPE_COMPILE, "jar", "");
+    }
+
+    private Artifact createArtifact(
+            String groupId, String artifactId, String version, String scope, String type, String classifier) {
+        DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+        Artifact artifact = new DefaultArtifact(
+                groupId, artifactId, VersionRange.createFromVersion(version), scope, type, classifier, handler, false);
+        artifact.setRelease(!artifact.isSnapshot());
+        return artifact;
+    }
+}

--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/EnforcerArtifactStubFactory.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/utils/EnforcerArtifactStubFactory.java
@@ -30,7 +30,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
  * Builds detached {@link Artifact} stubs for rule tests. No file is created and none is attached; a test that
  * needs one calls {@link Artifact#setFile}.
  */
-public class ArtifactStubFactory {
+public class EnforcerArtifactStubFactory {
 
     /**
      * @return {@code testGroupId:release:jar:1.0}, compile scope

--- a/pom.xml
+++ b/pom.xml
@@ -214,19 +214,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.maven.plugin-testing</groupId>
-        <artifactId>maven-plugin-testing-harness</artifactId>
-        <version>3.5.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <!-- used in test runtime for ArtifactStubFactory -->
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-archiver</artifactId>
-        <version>4.12.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.27.7</version>


### PR DESCRIPTION
`ArtifactStubFactory` was the only `maven-plugin-testing-harness` class the test tree used. It carries an `ArchiverManager` field and a `createUnpackableFile` declaring `NoSuchArchiverException`, so `plexus-archiver` had to be on the test classpath for the JVM to resolve types no test calls — the tests only ever ask for `getReleaseArtifact`, `getSnapshotArtifact`, `getScopedArtifacts`, `getTypedArtifacts` and `createArtifact`. Dropping it outright gives 36 `NoClassDefFoundError`s across 6 classes.

A ~90-line local factory replaces it, so both test dependencies go. Call sites are unchanged apart from the import.

Equivalence was checked before the swap with a throwaway test comparing 21 properties of every artifact both factories produce — coordinates, version range, scope, type, classifier, `hasClassifier`, optional, release/snapshot, id, dependency conflict id, file, and the handler's extension, packaging, directory, language, `addedToClasspath` and `includesDependencies`. All identical but one: the *handler's* classifier is `null` rather than `""`. The artifact's own classifier and `hasClassifier()` are unchanged, and nothing reads the handler's.

Verified: `mvn verify -DskipITs` → BUILD SUCCESS, 260/260 in enforcer-rules, spotless and RAT green. The test classpath loses 7 jars and 8.8 MB — zstd-jni (7.2M), commons-compress (1.1M), plexus-archiver, plexus-io, xz, the harness and plexus-testing.

Makes #1015 moot.

*This change was created with AI assistance.*