### PR TITLE
Decouple enforceBytecodeVersion ITs from the log4j-api fixture version

### DIFF
--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/pom.xml
@@ -27,13 +27,15 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- single source of truth: bumping the fixture is a one-line change, scripts stay untouched -->
+    <log4j.version>2.25.5</log4j.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.17.2</version>
+      <version>${log4j.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease-strict/verify.groovy
@@ -23,6 +23,11 @@ assert file.exists();
 String text = file.getText("utf-8");
 
 assert ! text.contains( '[INFO] Adding ignore: module-info' )
-assert text.contains( 'Found Banned Dependency: org.apache.logging.log4j:log4j-api:jar:2.17.2' )
+
+// the version must not be pinned here: bumping <log4j.version> in pom.xml
+// must not require editing this script
+def banned = text =~ /Found Banned Dependency: org\.apache\.logging\.log4j:log4j-api:jar:(\d[\d.]*)/
+assert banned.find() : 'expected log4j-api to be reported as banned'
+println "log4j-api ${banned.group(1)} correctly rejected in strict mode"
 
 return true;

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/pom.xml
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/pom.xml
@@ -51,13 +51,15 @@ under the License.
 	</build>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- single source of truth: bumping the fixture is a one-line change, scripts stay untouched -->
+		<log4j.version>2.25.5</log4j.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.2</version>
+			<version>${log4j.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>

--- a/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/verify.groovy
+++ b/maven-enforcer-plugin/src/it/projects/enforce-bytecode-version-multirelease/verify.groovy
@@ -22,8 +22,8 @@ assert file.exists()
 
 String text = file.getText("utf-8")
 
-// old
-// assert text.contains('[DEBUG] Ignore: module-info maps to regex ^module-info(\\.class)?$')
-// new
 assert text.contains('[DEBUG] Ignore: module-info (target < Java 8)')
-assert text.contains('[DEBUG] log4j-api-2.17.2.jar => ')
+
+// the version must not be pinned here: bumping <log4j.version> in pom.xml
+// must not require editing this script
+assert text =~ /\[DEBUG\] log4j-api-\d[\d.]*\.jar => /


### PR DESCRIPTION
The `enforce-bytecode-version-multirelease` and `enforce-bytecode-version-multirelease-strict` IT projects pinned the log4j-api version twice: once in the POM and again inside the `verify.groovy` assertions. Every fixture upgrade therefore required touching both files in sync, and a POM-only change failed the IT verification.

This PR moves the version into a `<log4j.version>` property and makes the assertions version-agnostic (anchored regexes on the `log4j-api` artifact), which decreases the maintenance cost of the ITs:

- future fixture bumps become a one-line POM change and can never desynchronise the verification scripts
- the tests keep asserting exactly the behaviour they exist for: analysis of multi-release JARs, `module-info` ignoring when `maxJdkVersion < 9`, and the strict-mode ban of classes above the maximum JDK
- both fixtures are refreshed to log4j-api 2.25.5

Testing:

- ran both IT projects locally against `maven-enforcer-plugin` 3.6.4-SNAPSHOT: `multirelease` passes, `strict` fails as required by its `invoker.buildResult = failure`, and the executed verify scripts pass in both cases
- verified the refactored scripts pass with the property set to both `2.17.2` and `2.25.5` (property-only change) and still fail when the expected log lines are absent

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`) for the affected projects.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
