### PR TITLE
Add tests for requireJavaVersion five-part JDK strings #980

### DIFF
--- a/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/version/TestRequireJavaVersion.java
+++ b/enforcer-rules/src/test/java/org/apache/maven/enforcer/rules/version/TestRequireJavaVersion.java
@@ -21,6 +21,7 @@ package org.apache.maven.enforcer.rules.version;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.enforcer.rule.api.EnforcerLogger;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,6 +77,8 @@ class TestRequireJavaVersion {
         assertThat(RequireJavaVersion.normalizeJDKVersion("9")).isEqualTo("9");
 
         assertThat(RequireJavaVersion.normalizeJDKVersion("17")).isEqualTo("17");
+        // 5-part runtime strings (Temurin 21.0.10.0.1) collapse to 4 tokens
+        assertThat(RequireJavaVersion.normalizeJDKVersion("21.0.10.0.1")).isEqualTo("21.0.10-0");
     }
 
     /**
@@ -92,6 +95,29 @@ class TestRequireJavaVersion {
         // test the singular version
         rule.execute();
         // intentionally no assertThat(...) because we don't expect and exception.
+    }
+
+    /**
+     * CI often pins {@code requireJavaVersion} to {@code ${java.version}}. That string can have more
+     * than four numeric tokens ({@code 21.0.10.0.1}); normalize then yields {@code 21.0.10-0}, which
+     * is not in the exact required range. The rule must accept the raw runtime string first (#967).
+     */
+    @Test
+    void exactFivePartJavaVersionIsAllowedEvenWhenNormalizedFormDiffers() throws EnforcerRuleException {
+        String exact = "21.0.10.0.1";
+        rule.enforceVersion("JDK", exact, new DefaultArtifactVersion(exact));
+    }
+
+    @Test
+    void normalizedFivePartJavaVersionIsNotInTheExactRequiredRange() {
+        assertThatThrownBy(() -> rule.enforceVersion("JDK", "21.0.10.0.1", new DefaultArtifactVersion("21.0.10-0")))
+                .isInstanceOf(EnforcerRuleException.class);
+    }
+
+    @Test
+    void settingsTheJavaVersionAsExactRuntimeVersionShouldNotFail() throws EnforcerRuleException {
+        rule.setVersion(SystemUtils.JAVA_VERSION);
+        rule.execute();
     }
 
     @Test


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

#980 asked for tests around #967. `requireJavaVersion` with `${java.version}` pins the raw runtime string. For `21.0.10.0.1` that normalizes to `21.0.10-0`, so the exact string has to be accepted first.

I added:

- `normalizeJDKVersion("21.0.10.0.1")` → `21.0.10-0`
- exact `21.0.10.0.1` is allowed
- the normalized form is not in that exact range
- `setVersion(SystemUtils.JAVA_VERSION)` then `execute()` still passes on the running JDK

`mvn -pl enforcer-rules -am verify -DskipITs -Dtest=TestRequireJavaVersion` is green here.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
